### PR TITLE
feat: save graph on localStorage

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -9,6 +9,7 @@
 
 <body>
     <div id="top-bar">
+        <button id="new-button" class="new-button" title="New">New</button>
         <button id="save-button" class="save-button" title="Save">Save</button>
         <button id="load-button" class="load-button" title="Load">Load</button>
         <button id="pause-button" class="pause-button" title="Pause"></button>

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,12 @@ export class GlobalContext {
     this.viewgraph = new ViewGraph(this.datagraph, this.viewport);
   }
 
+  load(datagraph: DataGraph) {
+    this.datagraph = datagraph;
+    this.viewport.clear();
+    this.viewgraph = new ViewGraph(this.datagraph, this.viewport);
+  }
+
   getViewport() {
     return this.viewport;
   }
@@ -88,6 +94,12 @@ export class Viewport extends pixi_viewport.Viewport {
         selectElement(null);
       }
     });
+  }
+
+  clear() {
+    this.removeChildren();
+    this.addChild(new Background());
+    this.moveCenter(WORLD_WIDTH / 2, WORLD_HEIGHT / 2);
   }
 
   private initializeMovement() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,8 +16,10 @@ import {
   AddPc,
   AddRouter,
   AddServer,
-  loadGraph,
-  saveGraph,
+  loadFromFile,
+  loadFromLocalStorage,
+  saveToFile,
+  saveToLocalStorage,
   selectElement,
 } from "./types/viewportManager";
 import { DataGraph } from "./types/graphs/datagraph";
@@ -310,31 +312,13 @@ export class RightBar {
   RightBar.getInstance();
 
   // Add router button
-  leftBar.addButton(
-    RouterSvg,
-    () => {
-      AddRouter(ctx);
-    },
-    "Add Router",
-  );
+  leftBar.addButton(RouterSvg, () => AddRouter(ctx), "Add Router");
 
   // Add server button
-  leftBar.addButton(
-    ServerSvg,
-    () => {
-      AddServer(ctx);
-    },
-    "Add Server",
-  );
+  leftBar.addButton(ServerSvg, () => AddServer(ctx), "Add Server");
 
   // Add PC button
-  leftBar.addButton(
-    ComputerSvg,
-    () => {
-      AddPc(ctx);
-    },
-    "Add PC",
-  );
+  leftBar.addButton(ComputerSvg, () => AddPc(ctx), "Add PC");
 
   ctx.initialize(viewport);
 
@@ -361,13 +345,8 @@ export class RightBar {
   const loadButton = document.getElementById("load-button");
   const saveButton = document.getElementById("save-button");
 
-  saveButton.onclick = () => {
-    saveGraph(ctx);
-  };
-
-  loadButton.onclick = () => {
-    loadGraph(ctx);
-  };
+  saveButton.onclick = () => saveToFile(ctx);
+  loadButton.onclick = () => loadFromFile(ctx);
 
   const pauseButton = document.getElementById("pause-button");
   let paused = false;
@@ -394,9 +373,7 @@ export class RightBar {
     }
   };
 
-  pauseButton.onclick = () => {
-    triggerPause();
-  };
+  pauseButton.onclick = triggerPause;
 
   document.body.onkeyup = function (e) {
     if (e.key === " " || e.code === "Space") {
@@ -404,6 +381,12 @@ export class RightBar {
       e.preventDefault();
     }
   };
+
+  // TODO: load from local storage directly, without first generating a context
+  loadFromLocalStorage(ctx);
+
+  // TODO: do this only when changes are made
+  setInterval(() => saveToLocalStorage(ctx), 5000);
 
   console.log("initialized!");
 })();

--- a/src/index.ts
+++ b/src/index.ts
@@ -366,22 +366,7 @@ export class RightBar {
   };
 
   loadButton.onclick = () => {
-    const input = document.createElement("input");
-    input.type = "file";
-    input.accept = ".json";
-
-    input.onchange = (event) => {
-      const file = (event.target as HTMLInputElement).files[0];
-      const reader = new FileReader();
-      reader.readAsText(file);
-
-      reader.onload = (readerEvent) => {
-        const jsonData = readerEvent.target.result as string;
-        loadGraph(jsonData, ctx);
-      };
-    };
-
-    input.click();
+    loadGraph(ctx);
   };
 
   const pauseButton = document.getElementById("pause-button");

--- a/src/index.ts
+++ b/src/index.ts
@@ -387,8 +387,18 @@ export class RightBar {
   // TODO: load from local storage directly, without first generating a context
   loadFromLocalStorage(ctx);
 
-  // TODO: do this only when changes are made
-  setInterval(() => saveToLocalStorage(ctx), 5000);
+  let saveIntervalId: NodeJS.Timeout | null = null;
+
+  ctx.getDataGraph().subscribeChanges(() => {
+    // Wait a bit after the last change to save
+    if (saveIntervalId) {
+      clearInterval(saveIntervalId);
+    }
+    saveIntervalId = setInterval(() => {
+      saveToLocalStorage(ctx);
+      clearInterval(saveIntervalId);
+    }, 100);
+  });
 
   console.log("initialized!");
 })();

--- a/src/index.ts
+++ b/src/index.ts
@@ -342,9 +342,11 @@ export class RightBar {
 
   window.addEventListener("resize", resize);
 
+  const newButton = document.getElementById("new-button");
   const loadButton = document.getElementById("load-button");
   const saveButton = document.getElementById("save-button");
 
+  newButton.onclick = () => ctx.load(new DataGraph());
   saveButton.onclick = () => saveToFile(ctx);
   loadButton.onclick = () => loadFromFile(ctx);
 

--- a/src/style.css
+++ b/src/style.css
@@ -104,6 +104,7 @@ canvas {
 }
 
 /* Styles for save and load buttons */
+.new-button,
 .save-button,
 .load-button {
   background-color: #007bff; /* Blue background */

--- a/src/types/graphs/datagraph.ts
+++ b/src/types/graphs/datagraph.ts
@@ -5,9 +5,53 @@ export interface GraphNode {
   connections: Set<number>;
 }
 
+export type GraphDataNode = {
+  id: number;
+  x: number;
+  y: number;
+  type: string;
+  connections: number[];
+};
+
+export type GraphData = GraphDataNode[];
+
 export class DataGraph {
   private devices = new Map<number, GraphNode>();
   private idCounter = 1;
+
+  static fromData(data: GraphData): DataGraph {
+    const dataGraph = new DataGraph();
+    data.forEach((nodeData: GraphDataNode) => {
+      // ADD DATAGRAPH AND EDGES
+      console.log(nodeData);
+      const connections = new Set(nodeData.connections);
+      const graphNode: GraphNode = {
+        x: nodeData.x,
+        y: nodeData.y,
+        type: nodeData.type,
+        connections: connections,
+      };
+      dataGraph.addDevice(nodeData.id, graphNode);
+    });
+    return dataGraph;
+  }
+
+  toData(): GraphData {
+    const graphData: GraphData = [];
+
+    // Serialize nodes
+    this.getDevices().forEach(([id, info]) => {
+      graphData.push({
+        id: id,
+        x: info.x,
+        y: info.y,
+        type: info.type, // Save the device type (Router, Server, PC)
+        connections: Array.from(info.connections.values()),
+      });
+    });
+
+    return graphData;
+  }
 
   // Add a new device to the graph
   addNewDevice(deviceInfo: { x: number; y: number; type: string }): number {
@@ -143,11 +187,5 @@ export class DataGraph {
     console.log(
       `Connection removed between devices ID: ${n1Id} and ID: ${n2Id}`,
     );
-  }
-
-  // Clear the graph
-  clear() {
-    this.devices.clear();
-    this.idCounter = 1;
   }
 }

--- a/src/types/graphs/datagraph.ts
+++ b/src/types/graphs/datagraph.ts
@@ -18,6 +18,7 @@ export type GraphData = GraphDataNode[];
 export class DataGraph {
   private devices = new Map<number, GraphNode>();
   private idCounter = 1;
+  private onChanges: (() => void)[] = [];
 
   static fromData(data: GraphData): DataGraph {
     const dataGraph = new DataGraph();
@@ -49,7 +50,6 @@ export class DataGraph {
         connections: Array.from(info.connections.values()),
       });
     });
-
     return graphData;
   }
 
@@ -62,20 +62,22 @@ export class DataGraph {
     };
     this.devices.set(id, graphnode);
     console.log(`Device added with ID ${id}`);
+    this.notifyChanges();
     return id;
   }
 
   // Add a device to the graph
   addDevice(idDevice: number, deviceInfo: GraphNode) {
-    if (!this.devices.has(idDevice)) {
-      this.devices.set(idDevice, deviceInfo);
-      if (this.idCounter <= idDevice) {
-        this.idCounter = idDevice + 1;
-      }
-      console.log(`Device added with ID ${idDevice}`);
-    } else {
+    if (this.devices.has(idDevice)) {
       console.warn(`Device with ID ${idDevice} already exists in the graph.`);
+      return;
     }
+    this.devices.set(idDevice, deviceInfo);
+    if (this.idCounter <= idDevice) {
+      this.idCounter = idDevice + 1;
+    }
+    console.log(`Device added with ID ${idDevice}`);
+    this.notifyChanges();
   }
 
   // Add a connection between two devices
@@ -84,23 +86,30 @@ export class DataGraph {
       console.warn(
         `Cannot create a connection between the same device (ID ${n1Id}).`,
       );
-    } else if (!this.devices.has(n1Id)) {
+      return;
+    }
+    if (!this.devices.has(n1Id)) {
       console.warn(`Device with ID ${n1Id} does not exist in devices.`);
-    } else if (!this.devices.has(n2Id)) {
+      return;
+    }
+    if (!this.devices.has(n2Id)) {
       console.warn(`Device with ID ${n2Id} does not exist in devices.`);
+      return;
       // Check if an edge already exists between these two devices
-    } else if (this.devices.get(n1Id).connections.has(n2Id)) {
+    }
+    if (this.devices.get(n1Id).connections.has(n2Id)) {
       console.warn(
         `Connection between ID ${n1Id} and ID ${n2Id} already exists.`,
       );
-    } else {
-      this.devices.get(n1Id).connections.add(n2Id);
-      this.devices.get(n2Id).connections.add(n1Id);
-
-      console.log(
-        `Connection created between devices ID: ${n1Id} and ID: ${n2Id}`,
-      );
+      return;
     }
+    this.devices.get(n1Id).connections.add(n2Id);
+    this.devices.get(n2Id).connections.add(n1Id);
+
+    console.log(
+      `Connection created between devices ID: ${n1Id} and ID: ${n2Id}`,
+    );
+    this.notifyChanges();
   }
 
   updateDevicePosition(id: number, newValues: { x?: number; y?: number }) {
@@ -110,6 +119,7 @@ export class DataGraph {
       return;
     }
     this.devices.set(id, { ...deviceGraphNode, ...newValues });
+    this.notifyChanges();
   }
 
   getDevice(id: number): GraphNode | undefined {
@@ -155,6 +165,7 @@ export class DataGraph {
     // Remove the node from the graph
     this.devices.delete(id);
     console.log(`Device with ID ${id} and its connections were removed.`);
+    this.notifyChanges();
   }
 
   // Method to remove a connection (edge) between two devices by their IDs
@@ -187,5 +198,14 @@ export class DataGraph {
     console.log(
       `Connection removed between devices ID: ${n1Id} and ID: ${n2Id}`,
     );
+    this.notifyChanges();
+  }
+
+  subscribeChanges(callback: () => void) {
+    this.onChanges.push(callback);
+  }
+
+  notifyChanges() {
+    this.onChanges.forEach((callback) => callback());
   }
 }

--- a/src/types/graphs/datagraph.ts
+++ b/src/types/graphs/datagraph.ts
@@ -5,13 +5,13 @@ export interface GraphNode {
   connections: Set<number>;
 }
 
-export type GraphDataNode = {
+export interface GraphDataNode {
   id: number;
   x: number;
   y: number;
   type: string;
   connections: number[];
-};
+}
 
 export type GraphData = GraphDataNode[];
 

--- a/src/types/graphs/viewgraph.ts
+++ b/src/types/graphs/viewgraph.ts
@@ -16,7 +16,7 @@ export class ViewGraph {
     this.constructView();
   }
 
-  constructView() {
+  private constructView() {
     // TODO: Adjust construction based on the selected layer in the future
     console.log("Constructing ViewGraph from DataGraph");
     const connections = new Set<{ deviceId: number; adyacentId: number }>();
@@ -178,17 +178,6 @@ export class ViewGraph {
   // Get the number of devices in the graph
   getDeviceCount(): number {
     return this.devices.size;
-  }
-
-  // Clear the graph
-  clear() {
-    this.devices.forEach((device) => {
-      device.delete();
-    });
-    // no edges should remain to delete
-    this.devices.clear();
-    this.edges.clear();
-    this.idCounter = 1;
   }
 
   // Method to remove a device and its connections (edges)

--- a/src/types/viewportManager.ts
+++ b/src/types/viewportManager.ts
@@ -178,28 +178,7 @@ function setDevice(
 
 // Function to save the current graph in JSON format
 export function saveGraph(ctx: GlobalContext) {
-  const datagraph: DataGraph = ctx.getDataGraph();
-
-  const graphData: {
-    id: number;
-    x: number;
-    y: number;
-    type: string;
-    connections: number[];
-  }[] = [];
-
-  // Serialize nodes
-  datagraph.getDevices().forEach((deviceInfo) => {
-    const id = deviceInfo[0];
-    const info = deviceInfo[1];
-    graphData.push({
-      id: id,
-      x: info.x,
-      y: info.y,
-      type: info.type, // Save the device type (Router, Server, PC)
-      connections: Array.from(info.connections.values()),
-    });
-  });
+  const graphData = ctx.getDataGraph().toData();
 
   // Convert to JSON and download
   const jsonString = JSON.stringify(graphData, null, 2);
@@ -217,29 +196,7 @@ export function saveGraph(ctx: GlobalContext) {
 // Function to load a graph from a JSON file
 export function loadGraph(jsonData: string, ctx: GlobalContext) {
   const graphData = JSON.parse(jsonData);
-  const viewgraph = ctx.getViewGraph();
-  const datagraph = ctx.getDataGraph();
-
-  // Clear current nodes and connections
-  viewgraph.clear();
-  datagraph.clear();
-
-  // Deserialize and recreate nodes
-  graphData.forEach(
-    (nodeData: {
-      id: number;
-      x: number;
-      y: number;
-      type: string;
-      connections: number[];
-    }) => {
-      // ADD DATAGRAPH AND EDGES
-      console.log(nodeData);
-      setDevice(datagraph, nodeData);
-    },
-  );
-
-  viewgraph.constructView();
+  ctx.load(DataGraph.fromData(graphData));
 
   console.log("Graph loaded successfully.");
 }

--- a/src/types/viewportManager.ts
+++ b/src/types/viewportManager.ts
@@ -198,14 +198,16 @@ export function loadFromFile(ctx: GlobalContext) {
 const LOCAL_STORAGE_KEY = "graphData";
 
 export function saveToLocalStorage(ctx: GlobalContext) {
-  const graphData = JSON.stringify(ctx.getDataGraph().toData());
+  const dataGraph = ctx.getDataGraph();
+  const graphData = JSON.stringify(dataGraph.toData());
   localStorage.setItem(LOCAL_STORAGE_KEY, graphData);
 
   console.log("Graph saved in local storage.");
 }
 
 export function loadFromLocalStorage(ctx: GlobalContext) {
-  const graphData = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) || "[]");
+  const jsonData = localStorage.getItem(LOCAL_STORAGE_KEY) || "[]";
+  const graphData = JSON.parse(jsonData);
   ctx.load(DataGraph.fromData(graphData));
 
   console.log("Graph loaded from local storage.");

--- a/src/types/viewportManager.ts
+++ b/src/types/viewportManager.ts
@@ -194,9 +194,24 @@ export function saveGraph(ctx: GlobalContext) {
 }
 
 // Function to load a graph from a JSON file
-export function loadGraph(jsonData: string, ctx: GlobalContext) {
-  const graphData = JSON.parse(jsonData);
-  ctx.load(DataGraph.fromData(graphData));
+export function loadGraph(ctx: GlobalContext) {
+  const input = document.createElement("input");
+  input.type = "file";
+  input.accept = ".json";
 
-  console.log("Graph loaded successfully.");
+  input.onchange = (event) => {
+    const file = (event.target as HTMLInputElement).files[0];
+    const reader = new FileReader();
+    reader.readAsText(file);
+
+    reader.onload = (readerEvent) => {
+      const jsonData = readerEvent.target.result as string;
+      const graphData = JSON.parse(jsonData);
+      ctx.load(DataGraph.fromData(graphData));
+
+      console.log("Graph loaded successfully.");
+    };
+  };
+
+  input.click();
 }

--- a/src/types/viewportManager.ts
+++ b/src/types/viewportManager.ts
@@ -1,5 +1,5 @@
 import { GlobalContext } from "./../index";
-import { DataGraph, GraphNode } from "./graphs/datagraph";
+import { DataGraph } from "./graphs/datagraph";
 import { Device, Pc, Router, Server } from "./devices/index";
 import { Edge } from "./edge";
 import { RightBar } from "../index"; // Ensure the path is correct

--- a/src/types/viewportManager.ts
+++ b/src/types/viewportManager.ts
@@ -155,27 +155,6 @@ export function AddServer(ctx: GlobalContext) {
   );
 }
 
-function setDevice(
-  datagraph: DataGraph,
-  nodeData: {
-    id: number;
-    x: number;
-    y: number;
-    type: string;
-    connections: number[];
-  },
-) {
-  const connections = new Set(nodeData.connections);
-  const graphNode: GraphNode = {
-    x: nodeData.x,
-    y: nodeData.y,
-    type: nodeData.type,
-    connections: connections,
-  };
-  datagraph.addDevice(nodeData.id, graphNode);
-  console.log(`Device set with ID ${nodeData.id}`);
-}
-
 // Function to save the current graph in JSON format
 export function saveGraph(ctx: GlobalContext) {
   const graphData = ctx.getDataGraph().toData();

--- a/src/types/viewportManager.ts
+++ b/src/types/viewportManager.ts
@@ -156,7 +156,7 @@ export function AddServer(ctx: GlobalContext) {
 }
 
 // Function to save the current graph in JSON format
-export function saveGraph(ctx: GlobalContext) {
+export function saveToFile(ctx: GlobalContext) {
   const graphData = ctx.getDataGraph().toData();
 
   // Convert to JSON and download
@@ -173,7 +173,7 @@ export function saveGraph(ctx: GlobalContext) {
 }
 
 // Function to load a graph from a JSON file
-export function loadGraph(ctx: GlobalContext) {
+export function loadFromFile(ctx: GlobalContext) {
   const input = document.createElement("input");
   input.type = "file";
   input.accept = ".json";
@@ -193,4 +193,20 @@ export function loadGraph(ctx: GlobalContext) {
   };
 
   input.click();
+}
+
+const LOCAL_STORAGE_KEY = "graphData";
+
+export function saveToLocalStorage(ctx: GlobalContext) {
+  const graphData = JSON.stringify(ctx.getDataGraph().toData());
+  localStorage.setItem(LOCAL_STORAGE_KEY, graphData);
+
+  console.log("Graph saved in local storage.");
+}
+
+export function loadFromLocalStorage(ctx: GlobalContext) {
+  const graphData = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) || "[]");
+  ctx.load(DataGraph.fromData(graphData));
+
+  console.log("Graph loaded from local storage.");
 }


### PR DESCRIPTION
Using [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) we can save the contents of the graph between restarts.

NOTE: this implementation has concurrency issues when multiple tabs are open.