### PR TITLE
fix: finishing packet sending when packet is selected

### DIFF
--- a/src/types/packet.ts
+++ b/src/types/packet.ts
@@ -5,7 +5,7 @@ import {
   Ticker,
 } from "pixi.js";
 import { Edge, Position } from "./edge";
-import { selectElement } from "./viewportManager";
+import { deselectElement, isSelected, selectElement } from "./viewportManager";
 import { circleGraphicsContext, Colors, ZIndexLevels } from "../utils";
 import { RightBar } from "../index";
 
@@ -116,6 +116,9 @@ export class Packet extends Graphics {
       this.removeFromParent();
       if (this.currentPath.length == 0) {
         ticker.remove(this.animationTick, this);
+        if (isSelected(this)) {
+          deselectElement();
+        }
         this.destroy();
         return;
       }

--- a/src/types/viewportManager.ts
+++ b/src/types/viewportManager.ts
@@ -35,6 +35,10 @@ export function refreshElement() {
   }
 }
 
+export function isSelected(element: Device | Edge | Packet) {
+  return element === selectedElement;
+}
+
 document.addEventListener("keydown", (event) => {
   if (event.key === "Delete" || event.key === "Backspace") {
     if (selectedElement) {


### PR DESCRIPTION
An error is thrown when a packet’s sending process ends with the packet being selected. The error was resolved by deselecting the packet once its sending process is complete.