### PR TITLE
fix: add device connection cancellation

### DIFF
--- a/src/types/devices/device.ts
+++ b/src/types/devices/device.ts
@@ -179,6 +179,10 @@ export abstract class Device extends Sprite {
   }
 
   selectToConnect() {
+    if (Device.connectionTarget) {
+      Device.connectionTarget = null;
+      return;
+    }
     Device.connectionTarget = this;
   }
 


### PR DESCRIPTION
Fixed an issue where pressing the connect button again did not cancel the connection process. The `selectToConnect` method now correctly handles connection cancellation by resetting the connection target if it is already set.

Closes #104 