### PR TITLE
feat: make router drop packets if full

### DIFF
--- a/src/types/devices/device.ts
+++ b/src/types/devices/device.ts
@@ -71,8 +71,7 @@ export abstract class Device extends Container {
   // Each type of device has different ways of handling a received packet.
   // Returns the DevicedId for the next device to send the packet to, or
   // null if there’s no next device to send the packet.
-  // TODO: Might be general for all device in the future.
-  abstract receivePacket(packet: Packet): DeviceId | null;
+  abstract receivePacket(packet: Packet): Promise<DeviceId | null>;
 
   constructor(
     id: DeviceId,

--- a/src/types/devices/host.ts
+++ b/src/types/devices/host.ts
@@ -58,7 +58,7 @@ export class Host extends Device {
     return DeviceType.Host;
   }
 
-  receivePacket(packet: Packet): DeviceId | null {
+  async receivePacket(packet: Packet): Promise<DeviceId | null> {
     if (this.ip.equals(packet.rawPacket.destinationAddress)) {
       this.handlePacket(packet);
     }

--- a/src/types/devices/switch.ts
+++ b/src/types/devices/switch.ts
@@ -34,7 +34,7 @@ export class Switch extends Device {
     return DeviceType.Switch;
   }
 
-  receivePacket(packet: Packet): DeviceId | null {
+  async receivePacket(packet: Packet): Promise<DeviceId | null> {
     console.log(packet); // lint
     throw new Error("Method not implemented.");
   }

--- a/src/types/packet.ts
+++ b/src/types/packet.ts
@@ -194,7 +194,11 @@ export class Packet extends Graphics {
       }
 
       this.currentStart = newStart;
+      // TODO: remove this dirty hack
+      // Remove and re-add from ticker to avoid multiple frames processing being triggered at once.
+      ticker.remove(this.animationTick, this);
       const newEndId = await newStartDevice.receivePacket(this);
+      ticker.add(this.animationTick, this);
 
       if (newEndId === null) {
         deleteSelf();

--- a/src/types/packet.ts
+++ b/src/types/packet.ts
@@ -170,7 +170,7 @@ export class Packet extends Graphics {
     Ticker.shared.add(this.animationTick, this);
   }
 
-  animationTick(ticker: Ticker) {
+  async animationTick(ticker: Ticker) {
     if (this.progress >= 1) {
       const deleteSelf = () => {
         this.destroy();
@@ -194,7 +194,7 @@ export class Packet extends Graphics {
       }
 
       this.currentStart = newStart;
-      const newEndId = newStartDevice.receivePacket(this);
+      const newEndId = await newStartDevice.receivePacket(this);
 
       if (newEndId === null) {
         deleteSelf();


### PR DESCRIPTION
Depends on #134

This PR adds a delay to packet processing on routers and a packet processing counter. When this counter reaches a limit packets start being dropped.