### PR TITLE
Avoid deleting packets between layers

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -43,9 +43,10 @@ export class GlobalContext {
     this.datagraph = datagraph;
     this.viewport.clear();
     if (this.viewgraph) {
-      this.viewgraph.clear();
+      this.viewgraph.changeCurrLayer(layer);
+    } else {
+      this.viewgraph = new ViewGraph(datagraph, this, layer);
     }
-    this.viewgraph = new ViewGraph(this.datagraph, this, layer);
     this.setIpGenerator();
     this.setMacGenerator();
   }

--- a/src/programs/echo_sender.ts
+++ b/src/programs/echo_sender.ts
@@ -63,7 +63,6 @@ export class SingleEcho extends ProgramBase {
     const path = this.viewgraph.getPathBetween(this.srcId, this.dstId);
     let dstMac = dstDevice.mac;
     if (!path) return;
-    console.log(path);
     for (const id of path.slice(1)) {
       const device = this.viewgraph.getDevice(id);
       // if there’s a router in the middle, first send frame to router mac

--- a/src/types/devices/device.ts
+++ b/src/types/devices/device.ts
@@ -146,6 +146,10 @@ export abstract class Device extends Container {
     this.connections.delete(id);
   }
 
+  isAdjacent(deviceId: DeviceId): boolean {
+    return this.connections.has(deviceId);
+  }
+
   delete(): void {
     this.viewgraph.removeDevice(this.id);
     console.log(`Device ${this.id} deleted`);

--- a/src/types/devices/networkDevice.ts
+++ b/src/types/devices/networkDevice.ts
@@ -63,6 +63,9 @@ export abstract class NetworkDevice extends Device {
 
   async receivePacket(packet: Packet): Promise<DeviceId | null> {
     const frame = packet.rawPacket;
+    console.debug(
+      `Dispositivo ${this.mac.toString()} recibe frame con destino ${frame.destination.toString()}`,
+    );
     if (this.mac.equals(frame.destination)) {
       return this.receiveDatagram(packet);
     }

--- a/src/types/devices/router.ts
+++ b/src/types/devices/router.ts
@@ -86,6 +86,9 @@ export class Router extends NetworkDevice {
     if (!(datagram instanceof IPv4Packet)) {
       return null;
     }
+    console.debug(
+      `Dispositivo ${this.ip.toString()} recibe datagram con destino ${datagram.destinationAddress.toString()}`,
+    );
     if (this.ip.equals(datagram.destinationAddress)) {
       this.handlePacket(datagram);
       return null;

--- a/src/types/edge.ts
+++ b/src/types/edge.ts
@@ -75,7 +75,7 @@ export class Edge extends Graphics {
 
     this.children.forEach((child) => {
       if (child instanceof Packet) {
-        child.updatePosition(this); // hay que recalcular la posicion
+        child.updatePosition(this);
       }
     });
   }
@@ -159,7 +159,7 @@ export class Edge extends Graphics {
   destroy() {
     // Delete all curr packets
     this.currPackets.forEach((packet) => this.deregisterPacket(packet));
-    
+
     deselectElement();
     super.destroy();
   }

--- a/src/types/edge.ts
+++ b/src/types/edge.ts
@@ -1,4 +1,4 @@
-import { Graphics, Point, Ticker } from "pixi.js";
+import { Graphics, Point } from "pixi.js";
 import { ViewGraph } from "./graphs/viewgraph";
 import { Device } from "./devices/index"; // Import the Device class
 import { deselectElement, selectElement, urManager } from "./viewportManager";

--- a/src/types/edge.ts
+++ b/src/types/edge.ts
@@ -157,6 +157,9 @@ export class Edge extends Graphics {
   }
 
   destroy() {
+    // Delete all curr packets
+    this.currPackets.forEach((packet) => this.deregisterPacket(packet));
+    
     deselectElement();
     super.destroy();
   }
@@ -194,5 +197,9 @@ export class Edge extends Graphics {
       this.currPackets.delete(packet);
       this.removeChild(packet);
     }
+  }
+
+  getPackets(): Set<Packet> {
+    return this.currPackets;
   }
 }

--- a/src/types/graphs/viewgraph.ts
+++ b/src/types/graphs/viewgraph.ts
@@ -182,25 +182,27 @@ export class ViewGraph {
   }
 
   // agregar paquetes:
-  //   calcular nueva 
+  //   calcular nueva
 
   changeCurrLayer(newLayer: Layer) {
-    
-    const packets = this.packetManager.getCurrPackets();
-    const packetRoutes = this.packetManager.getPacketsRoutes(packets);
-    
+    const packetsInTransit = this.packetManager.getPacketsInTransit();
+
+    const formerLayer = this.layer;
     this.layer = newLayer;
     this.clear();
     this.constructView();
 
-    this.packetManager.addPackets(packetRoutes);
+    this.packetManager.addPackets(
+      packetsInTransit,
+      layerIncluded(newLayer, formerLayer),
+    );
 
     const layerSelect = document.getElementById(
-        "layer-select",
+      "layer-select",
     ) as HTMLSelectElement;
     const event = new CustomEvent("layerChanged");
     layerSelect.dispatchEvent(event);
-}
+  }
 
   getSpeed(): number {
     return this.ctx.getCurrentSpeed().value;
@@ -328,7 +330,7 @@ export class ViewGraph {
 
   getDeviceByIP(ipAddress: IpAddress) {
     return this.getDevices().find((device) => {
-      return device instanceof NetworkDevice && device.ip == ipAddress;
+      return device instanceof NetworkDevice && device.ip.equals(ipAddress);
     });
   }
 

--- a/src/types/graphs/viewgraph.ts
+++ b/src/types/graphs/viewgraph.ts
@@ -174,10 +174,14 @@ export class ViewGraph {
     return this.layer;
   }
 
+  // agregar paquetes:
+  //   calcular nueva 
+
   changeCurrLayer(newLayer: Layer) {
     this.layer = newLayer;
     this.clear();
     this.constructView();
+    // agregar paquetes
     const layerSelect = document.getElementById(
       "layer-select",
     ) as HTMLSelectElement;
@@ -396,10 +400,12 @@ export class ViewGraph {
   }
 
   clear() {
+    // paquetes <- llamar metodos de getCurrPackets
     this.viewport.clear();
     this.devices.forEach((device) => device.destroy());
     this.devices.clear();
     this.edges.forEach((edge) => edge.destroy());
     this.edges.clear();
+    // return paquetes
   }
 }

--- a/src/types/packet.ts
+++ b/src/types/packet.ts
@@ -23,7 +23,7 @@ const contextPerPacketType: Record<string, GraphicsContext> = {
 const highlightedPacketContext = circleGraphicsContext(Colors.Violet, 0, 0, 6);
 
 export class Packet extends Graphics {
-  private packetId: string;
+  packetId: string;
   speed = 100;
   progress = 0;
   viewgraph: ViewGraph;
@@ -147,8 +147,23 @@ export class Packet extends Graphics {
       .initializePacketProgress(this.packetId, start, nextDevice);
 
     this.currentEdge.addChild(this);
-    this.updatePosition();
+    this.updatePosition(edge,this.progress);
     Ticker.shared.add(this.animationTick, this);
+
+    // OPCION 2
+    // recibe el id de un dispositivo
+    // dispositivo <- consigo disposito con nuevoDispositivoId
+    // idArista <- dispositivo.procesarPaquete
+    // arsita <- consigo aristo con idArsita
+    // arista.sendPacket()
+  }
+
+  async forwardPacket(currDeviceID: number) {
+    const currDevice = this.viewgraph.getDevice(currDeviceID);
+    const nextDeviceID = await currDevice.receivePacket(this); // esto va a pasar a ser edgeToForwardID
+    const edgeToForward = this.viewgraph.getEdge(Edge.generateConnectionKey({ n1: currDeviceID, n2: nextDeviceID}));
+    edgeToForward.forwardPacket(this);
+        
   }
 
   async animationTick(ticker: Ticker) {
@@ -249,22 +264,14 @@ export class Packet extends Graphics {
       }
     }
 
-    this.updatePosition();
-  }
-
-  updatePosition() {
-    const startPos = this.currentEdge.nodePosition(this.currentStart);
-    const endPos = this.currentEdge.nodePosition(
-      this.currentEdge.otherEnd(this.currentStart),
-    );
-    this.setPositionAlongEdge(startPos, endPos, this.progress);
+    this.updatePosition(this.currentEdge, this.progress);
   }
 
   /// Updates the position according to the current progress.
-  setPositionAlongEdge(start: Position, end: Position, progress: number) {
+  updatePosition(start: Position, end: Position, progress: number) {
     const dx = end.x - start.x;
     const dy = end.y - start.y;
-
+  
     this.x = start.x + progress * dx;
     this.y = start.y + progress * dy;
   }

--- a/src/types/packet.ts
+++ b/src/types/packet.ts
@@ -149,19 +149,33 @@ export class Packet extends Graphics {
 
   async forwardPacket(currDeviceID: number) {
     const currDevice = this.viewgraph.getDevice(currDeviceID);
-    const nextDeviceID = await currDevice.receivePacket(this); // esto va a pasar a ser edgeToForwardID
+    const nextDeviceID = await currDevice.receivePacket(this);
+
+    // Packet has reached its destination
     if (!nextDeviceID) {
       return;
     }
+
     const edgeToForward = this.viewgraph.getEdge(
       Edge.generateConnectionKey({ n1: currDeviceID, n2: nextDeviceID }),
     );
-    // chequear que la arista no sea undefined
-    this.currentEdge = edgeToForward;
-    edgeToForward.registerPacket(this);
+
+    // Packet has reached a dead end
+    if (!edgeToForward) {
+      return;
+    }
+
+    // Reset progress and start traversing the next edge
     this.progress = 0;
+
+    // Update current edge and start
+    this.currentStart = currDeviceID;
+    this.currentEdge = edgeToForward;
+    
+    edgeToForward.registerPacket(this);
     Ticker.shared.add(this.animationTick, this);
   }
+  
 
   async animationTick(ticker: Ticker) {
     const start = this.currentEdge.startPos;

--- a/src/types/packet.ts
+++ b/src/types/packet.ts
@@ -171,11 +171,10 @@ export class Packet extends Graphics {
     // Update current edge and start
     this.currentStart = currDeviceID;
     this.currentEdge = edgeToForward;
-    
+
     edgeToForward.registerPacket(this);
     Ticker.shared.add(this.animationTick, this);
   }
-  
 
   async animationTick(ticker: Ticker) {
     const start = this.currentEdge.startPos;
@@ -217,6 +216,9 @@ export class Packet extends Graphics {
   }
 
   delete() {
+    // Remove packet from Ticker to stop animation
+    Ticker.shared.remove(this.animationTick, this);
+
     // Remove logical tracking
     console.log(`[DATAGRAPH]: Removing packet ${this.packetId}`);
     this.viewgraph.getDataGraph().removePacketProgress(this.packetId);

--- a/src/types/packetManager.ts
+++ b/src/types/packetManager.ts
@@ -1,0 +1,63 @@
+import { Packet } from "./packet";
+import { DeviceId } from "./graphs/datagraph";
+import { Edge } from "./edge";
+import { ViewGraph } from "./graphs/viewgraph";
+
+export class PacketManager {
+    private viewGraph: ViewGraph;
+    
+    constructor(viewGraph: ViewGraph) {
+        this.viewGraph = viewGraph;
+    }
+
+    getCurrPackets(): Set<Packet> {
+        const allPackets = new Set<Packet>();
+        
+        this.viewGraph.getEdges().forEach((edge) => {
+            const edgePackets = edge.getPackets();
+            console.log(`[PACKETS] Edge ${edge.connectedNodes} packets: ${edgePackets}`);
+            edgePackets.forEach((packet) => allPackets.add(packet));
+        });
+        
+        console.log(`[PACKETS] All packets: ${allPackets.size}`);
+        return allPackets;
+    }
+
+    getPacketsRoutes(currPackets: Set<Packet>): Map<Packet, DeviceId[]> {
+        const packetRoutes = new Map<Packet, DeviceId[]>();
+        currPackets.forEach((packet) => {
+            const route = this.viewGraph.getPathBetween(packet.srcId, packet.dstId);
+            packetRoutes.set(packet, route);
+        });
+
+        return packetRoutes;
+    }
+
+    addPackets(packetRoutes: Map<Packet, DeviceId[]>) {
+        const packets = new Set<Packet>();
+
+        packetRoutes.forEach((route, packet) => {
+            packets.add(packet);
+        });
+
+        const newPacketRoutes = this.getPacketsRoutes(packets);
+
+        packetRoutes.forEach((route, packet) => {
+            const newRoute = newPacketRoutes.get(packet);
+            console.log(`[ROUTES] Packet ${packet} route: ${route} new route: ${newRoute}`);
+            console.log(`[ROUTE] Current Edge ${packet.currentEdge.connectedNodes.n1}-${packet.currentEdge.connectedNodes.n2}`);
+
+            // TODO: Calcular la cantidad de saltos para poder mantener mejor el progreso del paquete
+            const n1 = newRoute[0];
+            const n2 = newRoute[1];
+
+            const edgeId = Edge.generateConnectionKey({ n1, n2 });
+            const edge = this.viewGraph.getEdge(edgeId);
+
+            if (edge) {
+                edge.registerPacket(packet);
+                packet.traverseEdge(edge, packet.srcId);
+            }
+        });
+    }
+}

--- a/src/types/packetManager.ts
+++ b/src/types/packetManager.ts
@@ -1,6 +1,4 @@
-import { Packet, PacketInfo } from "./packet";
-import { DeviceId } from "./graphs/datagraph";
-import { Edge } from "./edge";
+import { Packet } from "./packet";
 import { ViewGraph } from "./graphs/viewgraph";
 
 export class PacketManager {
@@ -32,7 +30,8 @@ export class PacketManager {
 
   private getNewDevicesForLowerLayer(packetsInTransit: Packet[]) {
     packetsInTransit.forEach((packet) => {
-      const { prevDevice, nextDevice, currProgress } = packet.getPacketInfo();
+      const { prevDevice, nextDevice, currProgress } =
+        packet.getPacketLocation();
       const pathBetweenPackets = this.viewgraph.getPathBetween(
         prevDevice,
         nextDevice,
@@ -56,7 +55,7 @@ export class PacketManager {
   private getNewDevicesForUpperLayer(packetsInTransit: Packet[]) {
     console.debug("Entro al upper");
     packetsInTransit.forEach((packet) => {
-      const { prevDevice } = packet.getPacketInfo();
+      const { prevDevice } = packet.getPacketLocation();
       const pathBetweenPackets = this.viewgraph.getPathBetween(
         prevDevice,
         packet.dstId,


### PR DESCRIPTION
Regarding issue #135, This pull request introduces significant enhancements to the `DataGraph` and `Packet` classes in the `src/types/graphs/datagraph.ts` and `src/types/packet.ts` files, respectively. The main focus of these changes is to add logical representations of edges and track packet progress within the data graph.

### Enhancements to `DataGraph`:

* Added new interfaces `DataEdge` and `PacketProgress` to represent edges and packet progress logically.
* Introduced methods to manage edges, including `generateEdgeId`, `addDataEdge`, `initializePacketProgress`, `updatePacketProgress`, `movePacketToNextEdge`, `removePacketProgress`, `getEdgeBetween`, and `hasEdge`. [[1]](diffhunk://#diff-bcb6a89d8df64103817e55ceb947828fdaf5a107120b7347ccf63a3d3411ecc2R151-R161) [[2]](diffhunk://#diff-bcb6a89d8df64103817e55ceb947828fdaf5a107120b7347ccf63a3d3411ecc2R611-R692) [[3]](diffhunk://#diff-bcb6a89d8df64103817e55ceb947828fdaf5a107120b7347ccf63a3d3411ecc2R345-R347)

### Enhancements to `Packet`:

* Added a `packetId` to the `Packet` class for unique identification and tracking. [[1]](diffhunk://#diff-e546d6337dcb4e908b738659b527f00387c07ab30674ab0dfbd61edab3d03ff4R26) [[2]](diffhunk://#diff-e546d6337dcb4e908b738659b527f00387c07ab30674ab0dfbd61edab3d03ff4L48-L60)
* Updated the packet initialization to include logical tracking in `DataGraph`.
* Enhanced the `animationTick` method to update logical progress in `DataGraph` and log progress at 25% intervals.
* Modified the `delete` method to remove logical tracking from `DataGraph` when a packet is deleted.

These changes collectively improve the ability to manage and track the state and progress of packets within the data graph, providing a more robust and maintainable system.