### PR TITLE
refactor: move graph functionality to new `Graph` ADT

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -133,14 +133,14 @@ export class GlobalContext {
 
   private setIpGenerator() {
     let maxIp = IpAddress.parse("10.0.0.0");
-    this.datagraph.getDevices().forEach((device) => {
+    for (const [, device] of this.datagraph.getDevices()) {
       if (isNetworkNode(device)) {
         const ip = IpAddress.parse(device.ip);
         if (maxIp.octets < ip.octets) {
           maxIp = ip;
         }
       }
-    });
+    }
     // TODO: we should use IpAddress instead of string here and in Datagraph
     const baseIp = maxIp.toString();
     const mask = "255.255.255.255";
@@ -149,14 +149,14 @@ export class GlobalContext {
 
   private setMacGenerator() {
     let maxMac = MacAddress.parse("00:00:10:00:00:00");
-    this.datagraph.getDevices().forEach((device) => {
+    for (const [, device] of this.datagraph.getDevices()) {
       if (isLinkNode(device)) {
         const mac = MacAddress.parse(device.mac);
         if (maxMac.octets < mac.octets) {
           maxMac = mac;
         }
       }
-    });
+    }
     // TODO: we should use MacAddress instead of string here and in Datagraph
     const baseMac = maxMac.toString();
     this.macGenerator = new MacAddressGenerator(baseMac);

--- a/src/graphics/renderables/device_info.ts
+++ b/src/graphics/renderables/device_info.ts
@@ -42,11 +42,7 @@ export class DeviceInfo extends StyledInfo {
         () => {
           const deviceData = this.device.getCreateDevice();
           const currLayer = this.device.viewgraph.getLayer();
-          const move = new RemoveDeviceMove(
-            currLayer,
-            deviceData,
-            this.device.viewgraph,
-          );
+          const move = new RemoveDeviceMove(currLayer, deviceData);
           this.device.delete();
           urManager.push(move);
         },

--- a/src/types/devices/device.ts
+++ b/src/types/devices/device.ts
@@ -135,7 +135,8 @@ export abstract class Device extends Container {
   /// Returns the data needed to create the device
   getCreateDevice(): CreateDevice {
     const node = this.viewgraph.getDataGraph().getDevice(this.id);
-    return { id: this.id, node };
+    const connections = this.viewgraph.getDataGraph().getConnections(this.id);
+    return { id: this.id, node, connections };
   }
 
   addConnection(adjacentId: DeviceId) {

--- a/src/types/devices/utils.ts
+++ b/src/types/devices/utils.ts
@@ -11,6 +11,7 @@ import { Switch } from "./switch";
 export interface CreateDevice {
   id: DeviceId;
   node: GraphNode;
+  connections: DeviceId[];
 }
 
 export function createDevice(

--- a/src/types/graphs/datagraph.ts
+++ b/src/types/graphs/datagraph.ts
@@ -120,7 +120,8 @@ export interface NewDevice {
 }
 
 export class DataGraph {
-  private deviceGraph = new Graph<GraphNode, {}>();
+  // NOTE: we don't store data in edges yet
+  private deviceGraph = new Graph<GraphNode, unknown>();
   private idCounter: DeviceId = 1;
   private onChanges: (() => void)[] = [];
 
@@ -301,7 +302,7 @@ export class DataGraph {
 
   regenerateAllRoutingTables() {
     console.log("Regenerating all routing tables");
-    for (const [id, _] of this.deviceGraph.getVertices()) {
+    for (const [id] of this.deviceGraph.getVertices()) {
       this.regenerateRoutingTable(id);
     }
   }

--- a/src/types/graphs/datagraph.ts
+++ b/src/types/graphs/datagraph.ts
@@ -180,7 +180,7 @@ export class DataGraph {
   addDevice(
     idDevice: DeviceId,
     deviceInfo: GraphNode,
-    connections: DeviceId[] = [],
+    connections: DeviceId[],
   ) {
     if (this.deviceGraph.hasVertex(idDevice)) {
       console.warn(`Device with ID ${idDevice} already exists in the graph.`);

--- a/src/types/graphs/graph.ts
+++ b/src/types/graphs/graph.ts
@@ -15,6 +15,10 @@ export class Graph<Vertex, Edge> {
     return this.vertices.has(id);
   }
 
+  hasEdge(id: VertexId, otherId: VertexId): boolean {
+    return this.edges.has(id) && this.edges.get(id).has(otherId);
+  }
+
   getVertex(id: VertexId): Vertex | undefined {
     return this.vertices.get(id);
   }
@@ -23,11 +27,27 @@ export class Graph<Vertex, Edge> {
     return this.edges.get(id)?.get(otherId);
   }
 
-  getConnections(id: VertexId): VertexId[] | undefined {
+  getNeighbors(id: VertexId): VertexId[] | undefined {
     if (!this.hasVertex(id)) {
       return undefined;
     }
     return Array.from(this.edges.get(id).keys());
+  }
+
+  getVertices(): IterableIterator<[VertexId, Vertex]> {
+    return this.vertices.entries();
+  }
+
+  getVertexCount(): number {
+    return this.vertices.size;
+  }
+
+  /**
+   * Returns an iterator over all edges in the graph.
+   * @returns an iterator over all edges in the graph, with no duplicates.
+   */
+  getEdges(): IterableIterator<[VertexId, VertexId, Edge]> {
+    return edgeIterator(this.edges);
   }
 
   setVertex(id: VertexId, vertex: Vertex): void {
@@ -35,7 +55,7 @@ export class Graph<Vertex, Edge> {
     this.edges.set(id, new Map());
   }
 
-  setEdge(id: VertexId, otherId: VertexId, edge: Edge): void {
+  setEdge(id: VertexId, otherId: VertexId, edge: Edge = null): void {
     if (!this.hasVertex(id) || !this.hasVertex(otherId)) {
       return;
     }
@@ -61,5 +81,15 @@ export class Graph<Vertex, Edge> {
     }
     this.edges.get(id).delete(otherId);
     this.edges.get(otherId).delete(id);
+  }
+}
+
+function* edgeIterator<Edge>(
+  edges: Map<VertexId, Map<VertexId, Edge>>,
+): IterableIterator<[VertexId, VertexId, Edge]> {
+  for (const [id, nodeEdges] of edges) {
+    for (const [otherId, edge] of nodeEdges) {
+      yield [id, otherId, edge];
+    }
   }
 }

--- a/src/types/graphs/graph.ts
+++ b/src/types/graphs/graph.ts
@@ -4,12 +4,12 @@ export class Graph<Vertex, Edge> {
   /**
    * Holds all of the Vertex data.
    */
-  private vertices: Map<VertexId, Vertex> = new Map();
+  private vertices = new Map<VertexId, Vertex>();
   /**
    * Represents a connection matrix, with `edges[x][y]` representing the edge between vertices `x` and `y`.
    * Note that edges are symmetrical, so `edges[x][y]` is the same as `edges[y][x]`.
    */
-  private edges: Map<VertexId, Map<VertexId, Edge>> = new Map();
+  private edges = new Map<VertexId, Map<VertexId, Edge>>();
 
   hasVertex(id: VertexId): boolean {
     return this.vertices.has(id);

--- a/src/types/graphs/graph.ts
+++ b/src/types/graphs/graph.ts
@@ -52,7 +52,9 @@ export class Graph<Vertex, Edge> {
 
   setVertex(id: VertexId, vertex: Vertex): void {
     this.vertices.set(id, vertex);
-    this.edges.set(id, new Map());
+    if (!this.edges.has(id)) {
+      this.edges.set(id, new Map());
+    }
   }
 
   setEdge(id: VertexId, otherId: VertexId, edge: Edge = null): void {

--- a/src/types/graphs/graph.ts
+++ b/src/types/graphs/graph.ts
@@ -1,0 +1,65 @@
+export type VertexId = number;
+
+export class Graph<Vertex, Edge> {
+  /**
+   * Holds all of the Vertex data.
+   */
+  private vertices: Map<VertexId, Vertex> = new Map();
+  /**
+   * Represents a connection matrix, with `edges[x][y]` representing the edge between vertices `x` and `y`.
+   * Note that edges are symmetrical, so `edges[x][y]` is the same as `edges[y][x]`.
+   */
+  private edges: Map<VertexId, Map<VertexId, Edge>> = new Map();
+
+  hasVertex(id: VertexId): boolean {
+    return this.vertices.has(id);
+  }
+
+  getVertex(id: VertexId): Vertex | undefined {
+    return this.vertices.get(id);
+  }
+
+  getEdge(id: VertexId, otherId: VertexId): Edge | undefined {
+    return this.edges.get(id)?.get(otherId);
+  }
+
+  getConnections(id: VertexId): VertexId[] | undefined {
+    if (!this.hasVertex(id)) {
+      return undefined;
+    }
+    return Array.from(this.edges.get(id).keys());
+  }
+
+  setVertex(id: VertexId, vertex: Vertex): void {
+    this.vertices.set(id, vertex);
+    this.edges.set(id, new Map());
+  }
+
+  setEdge(id: VertexId, otherId: VertexId, edge: Edge): void {
+    if (!this.hasVertex(id) || !this.hasVertex(otherId)) {
+      return;
+    }
+    this.edges.get(id).set(otherId, edge);
+    this.edges.get(otherId).set(id, edge);
+  }
+
+  removeVertex(id: VertexId): void {
+    if (!this.vertices.delete(id)) {
+      return;
+    }
+    const edges = this.edges.get(id);
+    this.edges.delete(id);
+
+    edges.forEach((_, otherId) => {
+      this.edges.get(otherId).delete(id);
+    });
+  }
+
+  removeEdge(id: VertexId, otherId: VertexId): void {
+    if (!this.hasVertex(id) || !this.hasVertex(otherId)) {
+      return;
+    }
+    this.edges.get(id).delete(otherId);
+    this.edges.get(otherId).delete(id);
+  }
+}

--- a/src/types/graphs/viewgraph.ts
+++ b/src/types/graphs/viewgraph.ts
@@ -1,6 +1,6 @@
 import { Device, NetworkDevice } from "./../devices";
 import { Edge, EdgeEdges } from "./../edge";
-import { DataGraph, DeviceId, GraphNode } from "./datagraph";
+import { DataGraph, DeviceId } from "./datagraph";
 import { Viewport } from "../../graphics/viewport";
 import { Layer, layerIncluded } from "../devices/layer";
 import { CreateDevice, createDevice } from "../devices/utils";

--- a/src/types/undo-redo/moves/addRemoveDevice.ts
+++ b/src/types/undo-redo/moves/addRemoveDevice.ts
@@ -1,7 +1,7 @@
 import { Layer } from "../../devices/device";
 import { CreateDevice } from "../../devices/utils";
 import { ViewGraph } from "../../graphs/viewgraph";
-import { BaseMove, TypeMove } from "./move";
+import { BaseMove } from "./move";
 
 // Superclass for AddDeviceMove and RemoveDeviceMove
 export abstract class AddRemoveDeviceMove extends BaseMove {
@@ -43,8 +43,6 @@ export abstract class AddRemoveDeviceMove extends BaseMove {
 
 // "Move" is here because it conflicts with AddDevice from viewportManager
 export class AddDeviceMove extends AddRemoveDeviceMove {
-  type = TypeMove.AddDevice;
-
   undo(viewgraph: ViewGraph): void {
     this.removeDevice(viewgraph);
   }
@@ -55,8 +53,6 @@ export class AddDeviceMove extends AddRemoveDeviceMove {
 }
 
 export class RemoveDeviceMove extends AddRemoveDeviceMove {
-  type: TypeMove = TypeMove.RemoveDevice;
-
   undo(viewgraph: ViewGraph): void {
     this.addDevice(viewgraph);
   }

--- a/src/types/undo-redo/moves/addRemoveDevice.ts
+++ b/src/types/undo-redo/moves/addRemoveDevice.ts
@@ -73,7 +73,7 @@ export class RemoveDeviceMove extends AddRemoveDeviceMove {
     }
 
     // Guardar las tablas de los dispositivos conectados
-    data.node.connections.forEach((adjacentId) => {
+    data.connections.forEach((adjacentId) => {
       const routingTable = viewgraph.getRoutingTable(adjacentId);
       if (routingTable) {
         this.storedRoutingTables.set(adjacentId, [...routingTable]);

--- a/src/types/undo-redo/moves/addRemoveDevice.ts
+++ b/src/types/undo-redo/moves/addRemoveDevice.ts
@@ -20,7 +20,10 @@ export abstract class AddRemoveDeviceMove extends BaseMove {
 
     // Add the device to the datagraph and the viewgraph
     const deviceInfo = structuredClone(this.data.node);
-    datagraph.addDevice(this.data.id, deviceInfo);
+    // Clone array to avoid modifying the original
+    const connections = Array.from(this.data.connections);
+
+    datagraph.addDevice(this.data.id, deviceInfo, connections);
 
     this.adjustLayer(viewgraph);
 
@@ -51,7 +54,6 @@ export class AddDeviceMove extends AddRemoveDeviceMove {
   }
 }
 
-// Check if the viewgraph is the best place to load the move into the manager
 export class RemoveDeviceMove extends AddRemoveDeviceMove {
   type: TypeMove = TypeMove.RemoveDevice;
   private storedRoutingTables: Map<DeviceId, RoutingTableEntry[]>;
@@ -59,7 +61,7 @@ export class RemoveDeviceMove extends AddRemoveDeviceMove {
   constructor(
     layer: Layer,
     data: CreateDevice,
-    viewgraph: ViewGraph, // Pasamos la vista para obtener las tablas de enrutamiento
+    viewgraph: ViewGraph, // To fetch routing tables
   ) {
     super(layer, data);
     this.storedRoutingTables = new Map();

--- a/src/types/undo-redo/moves/addRemoveDevice.ts
+++ b/src/types/undo-redo/moves/addRemoveDevice.ts
@@ -1,6 +1,5 @@
-import { DeviceType, Layer } from "../../devices/device";
+import { Layer } from "../../devices/device";
 import { CreateDevice } from "../../devices/utils";
-import { DeviceId, RoutingTableEntry } from "../../graphs/datagraph";
 import { ViewGraph } from "../../graphs/viewgraph";
 import { BaseMove, TypeMove } from "./move";
 
@@ -24,6 +23,7 @@ export abstract class AddRemoveDeviceMove extends BaseMove {
     const connections = Array.from(this.data.connections);
 
     datagraph.addDevice(this.data.id, deviceInfo, connections);
+    datagraph.regenerateAllRoutingTables();
 
     this.adjustLayer(viewgraph);
 
@@ -56,50 +56,9 @@ export class AddDeviceMove extends AddRemoveDeviceMove {
 
 export class RemoveDeviceMove extends AddRemoveDeviceMove {
   type: TypeMove = TypeMove.RemoveDevice;
-  private storedRoutingTables: Map<DeviceId, RoutingTableEntry[]>;
-
-  constructor(
-    layer: Layer,
-    data: CreateDevice,
-    viewgraph: ViewGraph, // To fetch routing tables
-  ) {
-    super(layer, data);
-    this.storedRoutingTables = new Map();
-
-    // Guardar la tabla de enrutamiento del dispositivo eliminado si es un router
-    if (data.node.type === DeviceType.Router) {
-      const routingTable = viewgraph.getRoutingTable(data.id);
-      if (routingTable) {
-        this.storedRoutingTables.set(data.id, [...routingTable]);
-      }
-    }
-
-    // Guardar las tablas de los dispositivos conectados
-    data.connections.forEach((adjacentId) => {
-      const routingTable = viewgraph.getRoutingTable(adjacentId);
-      if (routingTable) {
-        this.storedRoutingTables.set(adjacentId, [...routingTable]);
-      }
-    });
-
-    console.log(
-      "Stored routing tables before removal:",
-      this.storedRoutingTables,
-    );
-  }
 
   undo(viewgraph: ViewGraph): void {
     this.addDevice(viewgraph);
-
-    // Restaurar las tablas de enrutamiento de todos los dispositivos involucrados
-    this.storedRoutingTables.forEach((table, deviceId) => {
-      viewgraph.getDataGraph().setRoutingTable(deviceId, table);
-    });
-
-    console.log(
-      `Routing tables restored for devices:`,
-      this.storedRoutingTables.keys(),
-    );
   }
 
   redo(viewgraph: ViewGraph): void {

--- a/src/types/undo-redo/moves/addRemoveEdge.ts
+++ b/src/types/undo-redo/moves/addRemoveEdge.ts
@@ -2,7 +2,7 @@ import { Layer } from "../../devices/layer";
 import { Edge, EdgeEdges } from "../../edge";
 import { DeviceId, RoutingTableEntry } from "../../graphs/datagraph";
 import { ViewGraph } from "../../graphs/viewgraph";
-import { BaseMove, TypeMove } from "./move";
+import { BaseMove } from "./move";
 
 export abstract class AddRemoveEdgeMove extends BaseMove {
   connectedNodes: EdgeEdges;
@@ -35,8 +35,6 @@ export abstract class AddRemoveEdgeMove extends BaseMove {
 }
 
 export class AddEdgeMove extends AddRemoveEdgeMove {
-  type: TypeMove = TypeMove.AddEdge;
-
   undo(viewgraph: ViewGraph): void {
     this.removeEdge(viewgraph);
   }
@@ -47,7 +45,6 @@ export class AddEdgeMove extends AddRemoveEdgeMove {
 }
 
 export class RemoveEdgeMove extends AddRemoveEdgeMove {
-  type: TypeMove = TypeMove.RemoveEdge;
   private storedRoutingTables: Map<DeviceId, RoutingTableEntry[]>;
 
   constructor(

--- a/src/types/undo-redo/moves/dragDevice.ts
+++ b/src/types/undo-redo/moves/dragDevice.ts
@@ -2,10 +2,9 @@ import { Position } from "../../common";
 import { Layer } from "../../devices/layer";
 import { DeviceId } from "../../graphs/datagraph";
 import { ViewGraph } from "../../graphs/viewgraph";
-import { BaseMove, TypeMove } from "./move";
+import { BaseMove } from "./move";
 
 export class DragDeviceMove extends BaseMove {
-  type: TypeMove = TypeMove.DragDevice;
   did: DeviceId;
   startPosition: Position;
   endPosition: Position;

--- a/src/types/undo-redo/moves/move.ts
+++ b/src/types/undo-redo/moves/move.ts
@@ -26,7 +26,6 @@ export abstract class BaseMove implements Move {
 
   adjustLayer(viewgraph: ViewGraph) {
     if (!layerIncluded(this.layerInMove, viewgraph.getLayer())) {
-      console.log("Entre a cambiar el layer del viewgraph");
       viewgraph.changeCurrLayer(this.layerInMove);
     }
   }

--- a/src/types/undo-redo/moves/move.ts
+++ b/src/types/undo-redo/moves/move.ts
@@ -1,21 +1,12 @@
 import { Layer, layerIncluded } from "../../devices/layer";
 import { ViewGraph } from "../../graphs/viewgraph";
 
-export enum TypeMove {
-  AddDevice,
-  RemoveDevice,
-  AddEdge,
-  RemoveEdge,
-  DragDevice,
-}
-
 export interface Move {
   undo(viewgraph: ViewGraph): void;
   redo(viewgraph: ViewGraph): void;
 }
 
 export abstract class BaseMove implements Move {
-  abstract type: TypeMove;
   layerInMove: Layer;
   abstract undo(viewgraph: ViewGraph): void;
   abstract redo(viewgraph: ViewGraph): void;

--- a/src/types/undo-redo/moves/move.ts
+++ b/src/types/undo-redo/moves/move.ts
@@ -10,8 +10,6 @@ export enum TypeMove {
 }
 
 export interface Move {
-  type: TypeMove;
-  layerInMove: Layer;
   undo(viewgraph: ViewGraph): void;
   redo(viewgraph: ViewGraph): void;
 }

--- a/src/types/viewportManager.ts
+++ b/src/types/viewportManager.ts
@@ -74,11 +74,7 @@ document.addEventListener("keydown", (event) => {
       const currLayer = selectedElement.viewgraph.getLayer();
       if (isDevice(selectedElement)) {
         data = selectedElement.getCreateDevice();
-        const move = new RemoveDeviceMove(
-          currLayer,
-          data,
-          selectedElement.viewgraph,
-        );
+        const move = new RemoveDeviceMove(currLayer, data);
         selectedElement.delete();
         urManager.push(move);
       } else if (isEdge(selectedElement)) {

--- a/src/types/viewportManager.ts
+++ b/src/types/viewportManager.ts
@@ -143,8 +143,9 @@ export function addDevice(ctx: GlobalContext, type: DeviceType) {
 
   const id = datagraph.addNewDevice(deviceInfo);
   const node = datagraph.getDevice(id);
+  const connections = datagraph.getConnections(id);
 
-  const deviceData: CreateDevice = { id, node };
+  const deviceData: CreateDevice = { id, node, connections };
 
   // Add the Device to the graph
   const newDevice = viewgraph.addDevice(deviceData);


### PR DESCRIPTION
This PR adds a `Graph` class with the simple logic of storing nodes and edges, and uses it internally in the `DataGraph` class.