### PR TITLE
refactor: add edge object to datagraph

### DIFF
--- a/src/graphics/renderables/device_info.ts
+++ b/src/graphics/renderables/device_info.ts
@@ -46,8 +46,7 @@ export class DeviceInfo extends StyledInfo {
           const deviceData = this.device.getCreateDevice();
           const currLayer = this.device.viewgraph.getLayer();
           const move = new RemoveDeviceMove(currLayer, deviceData);
-          this.device.delete();
-          urManager.push(move);
+          urManager.push(this.device.viewgraph, move);
         },
         "right-bar-delete-button",
       ),

--- a/src/graphics/renderables/device_info.ts
+++ b/src/graphics/renderables/device_info.ts
@@ -43,9 +43,8 @@ export class DeviceInfo extends StyledInfo {
       createRightBarButton(
         "Delete device",
         () => {
-          const deviceData = this.device.getCreateDevice();
           const currLayer = this.device.viewgraph.getLayer();
-          const move = new RemoveDeviceMove(currLayer, deviceData);
+          const move = new RemoveDeviceMove(currLayer, this.device.id);
           urManager.push(this.device.viewgraph, move);
         },
         "right-bar-delete-button",

--- a/src/handlers/undoRedoHandler.ts
+++ b/src/handlers/undoRedoHandler.ts
@@ -29,7 +29,7 @@ export class UndoRedoHandler {
 
     if (this.undoButton && this.redoButton) {
       this.setupButtons();
-      urManager.suscribe(() => this.updateButtons());
+      urManager.subscribe(() => this.updateButtons());
     }
     this.setupShortcuts();
   }

--- a/src/types/devices/device.ts
+++ b/src/types/devices/device.ts
@@ -152,17 +152,6 @@ export abstract class Device extends Container {
     this.parent.on("pointerup", onPointerUp);
   }
 
-  // TODO: why is this even here??
-  connectTo(adjacentId: DeviceId): boolean {
-    // Connects both devices with an edge.
-    const move = new AddEdgeMove(this.viewgraph.getLayer(), {
-      n1: this.id,
-      n2: adjacentId,
-    });
-    urManager.push(this.viewgraph, move);
-    return true;
-  }
-
   onClick(e: FederatedPointerEvent) {
     e.stopPropagation();
 
@@ -170,12 +159,15 @@ export abstract class Device extends Container {
       selectElement(this);
       return;
     }
-    // If the stored device is this, reset it
+    // If the stored device is this, ignore
     if (Device.connectionTarget === this) {
       return;
     }
-    // The "LineStart" device ends up as the end of the drawing but it's the same
-    if (this.connectTo(Device.connectionTarget.id)) {
+    // Connect both devices
+    const n1 = Device.connectionTarget.id;
+    const n2 = this.id;
+    const move = new AddEdgeMove(this.viewgraph.getLayer(), { n1, n2 });
+    if (urManager.push(this.viewgraph, move)) {
       refreshElement();
       Device.connectionTarget = null;
     }

--- a/src/types/devices/device.ts
+++ b/src/types/devices/device.ts
@@ -252,7 +252,6 @@ export abstract class Device extends Container {
   abstract getLayer(): Layer;
 
   destroy() {
-    // Clear connections
     deselectElement();
     super.destroy();
   }

--- a/src/types/devices/device.ts
+++ b/src/types/devices/device.ts
@@ -19,7 +19,7 @@ import { Colors, ZIndexLevels } from "../../utils";
 import { Position } from "../common";
 import { DeviceInfo } from "../../graphics/renderables/device_info";
 import { IpAddress } from "../../packets/ip";
-import { DeviceId, GraphNode } from "../graphs/datagraph";
+import { DeviceId, GraphNode, RemovedNodeData } from "../graphs/datagraph";
 import { DragDeviceMove, AddEdgeMove } from "../undo-redo";
 import { Layer } from "./layer";
 import { Packet } from "../packet";
@@ -136,17 +136,11 @@ export abstract class Device extends Container {
     this.addChild(idText); // Add the ID text as a child of the device
   }
 
-  /// Returns the data needed to create the device
-  getCreateDevice(): CreateDevice {
-    const node = this.viewgraph.getDataGraph().getDevice(this.id);
-    const connections = this.viewgraph.getDataGraph().getConnections(this.id);
-    return { id: this.id, node, connections };
-  }
-
-  delete(): void {
-    this.viewgraph.removeDevice(this.id);
+  delete(): RemovedNodeData {
+    const deviceData = this.viewgraph.removeDevice(this.id);
     console.log(`Device ${this.id} deleted`);
     this.destroy();
+    return deviceData;
   }
 
   onPointerDown(event: FederatedPointerEvent): void {

--- a/src/types/devices/device.ts
+++ b/src/types/devices/device.ts
@@ -19,15 +19,20 @@ import { Colors, ZIndexLevels } from "../../utils";
 import { Position } from "../common";
 import { DeviceInfo } from "../../graphics/renderables/device_info";
 import { IpAddress } from "../../packets/ip";
-import { DeviceId } from "../graphs/datagraph";
+import { DeviceId, GraphNode } from "../graphs/datagraph";
 import { DragDeviceMove, AddEdgeMove } from "../undo-redo";
 import { Layer } from "./layer";
 import { Packet } from "../packet";
-import { CreateDevice } from "./utils";
 import { MacAddress } from "../../packets/ethernet";
 import { GlobalContext } from "../../context";
 
 export { Layer } from "./layer";
+
+interface CreateDevice {
+  id: DeviceId;
+  node: GraphNode;
+  connections: DeviceId[];
+}
 
 export enum DeviceType {
   Router = 0,

--- a/src/types/devices/device.ts
+++ b/src/types/devices/device.ts
@@ -19,7 +19,7 @@ import { Colors, ZIndexLevels } from "../../utils";
 import { Position } from "../common";
 import { DeviceInfo } from "../../graphics/renderables/device_info";
 import { IpAddress } from "../../packets/ip";
-import { DeviceId, GraphNode, RemovedNodeData } from "../graphs/datagraph";
+import { DeviceId, RemovedNodeData } from "../graphs/datagraph";
 import { DragDeviceMove, AddEdgeMove } from "../undo-redo";
 import { Layer } from "./layer";
 import { Packet } from "../packet";
@@ -27,12 +27,6 @@ import { MacAddress } from "../../packets/ethernet";
 import { GlobalContext } from "../../context";
 
 export { Layer } from "./layer";
-
-interface CreateDevice {
-  id: DeviceId;
-  node: GraphNode;
-  connections: DeviceId[];
-}
 
 export enum DeviceType {
   Router = 0,

--- a/src/types/devices/host.ts
+++ b/src/types/devices/host.ts
@@ -140,6 +140,7 @@ export class Host extends NetworkDevice {
   }
 
   destroy() {
+    super.destroy();
     this.runningPrograms.forEach((program) => program.stop());
     this.runningPrograms.clear();
   }

--- a/src/types/devices/index.ts
+++ b/src/types/devices/index.ts
@@ -4,4 +4,3 @@ export { Device } from "./device";
 export { NetworkDevice } from "./networkDevice";
 export { Router } from "./router";
 export { Host } from "./host";
-export { createDevice } from "./utils";

--- a/src/types/devices/utils.ts
+++ b/src/types/devices/utils.ts
@@ -16,32 +16,33 @@ export interface CreateDevice {
 }
 
 export function createDevice(
-  deviceInfo: CreateDevice,
+  id: DeviceId,
+  node: GraphNode,
   viewgraph: ViewGraph,
   ctx: GlobalContext,
 ): Device {
-  const position: { x: number; y: number } = deviceInfo.node;
+  const position: { x: number; y: number } = node;
   let mac: MacAddress;
 
-  if (isLinkNode(deviceInfo.node)) {
-    mac = MacAddress.parse(deviceInfo.node.mac);
+  if (isLinkNode(node)) {
+    mac = MacAddress.parse(node.mac);
   }
 
   let ip: IpAddress;
   let mask: IpAddress;
 
-  if (isNetworkNode(deviceInfo.node)) {
-    ip = IpAddress.parse(deviceInfo.node.ip);
-    mask = IpAddress.parse(deviceInfo.node.mask);
-    mac = MacAddress.parse(deviceInfo.node.mac);
+  if (isNetworkNode(node)) {
+    ip = IpAddress.parse(node.ip);
+    mask = IpAddress.parse(node.mask);
+    mac = MacAddress.parse(node.mac);
   }
 
-  switch (deviceInfo.node.type) {
+  switch (node.type) {
     case DeviceType.Router:
-      return new Router(deviceInfo.id, viewgraph, ctx, position, mac, ip, mask);
+      return new Router(id, viewgraph, ctx, position, mac, ip, mask);
     case DeviceType.Host:
-      return new Host(deviceInfo.id, viewgraph, ctx, position, mac, ip, mask);
+      return new Host(id, viewgraph, ctx, position, mac, ip, mask);
     case DeviceType.Switch:
-      return new Switch(deviceInfo.id, viewgraph, ctx, position, mac);
+      return new Switch(id, viewgraph, ctx, position, mac);
   }
 }

--- a/src/types/devices/utils.ts
+++ b/src/types/devices/utils.ts
@@ -9,12 +9,6 @@ import { Host } from "./host";
 import { Router } from "./router";
 import { Switch } from "./switch";
 
-export interface CreateDevice {
-  id: DeviceId;
-  node: GraphNode;
-  connections: DeviceId[];
-}
-
 export function createDevice(
   id: DeviceId,
   node: GraphNode,

--- a/src/types/edge.ts
+++ b/src/types/edge.ts
@@ -115,26 +115,23 @@ export class Edge extends Graphics {
     this.rightbar.addButton(
       "Delete Edge",
       () => {
+        const viewgraph = this.viewgraph;
         // Obtener las tablas de enrutamiento antes de eliminar la conexión
-        const routingTable1 = this.viewgraph.getRoutingTable(
-          this.connectedNodes.n1,
-        );
-        const routingTable2 = this.viewgraph.getRoutingTable(
-          this.connectedNodes.n2,
-        );
+        const routingTable1 = viewgraph.getRoutingTable(this.connectedNodes.n1);
+        const routingTable2 = viewgraph.getRoutingTable(this.connectedNodes.n2);
 
         // Crear el movimiento de eliminación de la arista con la información adicional
+        const routingTables = new Map([
+          [this.connectedNodes.n1, routingTable1],
+          [this.connectedNodes.n2, routingTable2],
+        ]);
         const move = new RemoveEdgeMove(
-          this.viewgraph.getLayer(),
+          viewgraph.getLayer(),
           this.connectedNodes,
-          new Map([
-            [this.connectedNodes.n1, routingTable1],
-            [this.connectedNodes.n2, routingTable2],
-          ]),
+          routingTables,
         );
 
-        this.delete();
-        urManager.push(move);
+        urManager.push(viewgraph, move);
       },
       "right-bar-delete-button",
     );

--- a/src/types/graphs/datagraph.ts
+++ b/src/types/graphs/datagraph.ts
@@ -278,6 +278,11 @@ export class DataGraph {
   }
 
   // Get all connections of a device
+  getConnection(n1Id: DeviceId, n2Id: DeviceId): GraphEdge | undefined {
+    return this.deviceGraph.getEdge(n1Id, n2Id);
+  }
+
+  // Get all connections of a device
   getConnections(id: DeviceId): DeviceId[] | undefined {
     return this.deviceGraph.getNeighbors(id);
   }

--- a/src/types/graphs/datagraph.ts
+++ b/src/types/graphs/datagraph.ts
@@ -141,7 +141,7 @@ export class DataGraph {
 
     data.nodes.forEach((nodeData: GraphDataNode) => {
       console.log(nodeData);
-      dataGraph.addDevice(nodeData.id, nodeData, []);
+      dataGraph.addExistingDevice(nodeData);
     });
 
     data.edges.forEach((edgeData: GraphEdge) => {
@@ -187,25 +187,26 @@ export class DataGraph {
     return id;
   }
 
+  readdDevice(removedData: RemovedNodeData) {
+    const { id, vertex, edges } = removedData;
+    this.deviceGraph.setVertex(id, vertex);
+    edges.forEach((edge) => {
+      this.deviceGraph.setEdge(edge.from.id, edge.to.id, edge);
+    });
+    this.notifyChanges();
+  }
+
   // Add a device to the graph
-  addDevice(
-    idDevice: DeviceId,
-    deviceInfo: GraphNode,
-    connections: DeviceId[],
-  ) {
-    if (this.deviceGraph.hasVertex(idDevice)) {
-      console.warn(`Device with ID ${idDevice} already exists in the graph.`);
+  addExistingDevice(node: GraphNode) {
+    if (this.deviceGraph.hasVertex(node.id)) {
+      console.warn(`Device with ID ${node.id} already exists in the graph.`);
       return;
     }
-    this.deviceGraph.setVertex(idDevice, deviceInfo);
-    connections.forEach((connectedId) => {
-      const edge = { from: { id: idDevice }, to: { id: connectedId } };
-      this.deviceGraph.setEdge(idDevice, connectedId, edge);
-    });
-    if (this.idCounter <= idDevice) {
-      this.idCounter = idDevice + 1;
+    this.deviceGraph.setVertex(node.id, node);
+    if (this.idCounter <= node.id) {
+      this.idCounter = node.id + 1;
     }
-    console.log(`Device added with ID ${idDevice}`);
+    console.log(`Device added with ID ${node.id}`);
     this.notifyChanges();
   }
 

--- a/src/types/graphs/datagraph.ts
+++ b/src/types/graphs/datagraph.ts
@@ -197,10 +197,16 @@ export class DataGraph {
     const graphnode: GraphNode = {
       ...deviceInfo,
       id,
-      routingTable: [],
-      runningPrograms: [],
-      arpTable: new Map(),
     };
+    if (isRouter(graphnode)) {
+      graphnode.routingTable = [];
+    }
+    if (isSwitch(graphnode)) {
+      graphnode.arpTable = new Map();
+    }
+    if (isHost(graphnode)) {
+      graphnode.runningPrograms = [];
+    }
     this.deviceGraph.setVertex(id, graphnode);
     console.log(`Device added with ID ${id}`);
     this.notifyChanges();

--- a/src/types/graphs/datagraph.ts
+++ b/src/types/graphs/datagraph.ts
@@ -121,7 +121,9 @@ interface GraphEdge {
   to: EdgeTip;
 }
 
-export type GraphData = GraphDataNode[];
+export interface GraphData {
+  nodes: GraphDataNode[];
+}
 
 export interface NewDevice {
   x: number;
@@ -140,7 +142,7 @@ export class DataGraph {
 
   static fromData(data: GraphData): DataGraph {
     const dataGraph = new DataGraph();
-    data.forEach((nodeData: GraphDataNode) => {
+    data.nodes.forEach((nodeData: GraphDataNode) => {
       console.log(nodeData);
 
       let graphNode: GraphNode = nodeData;
@@ -161,7 +163,7 @@ export class DataGraph {
   }
 
   toData(): GraphData {
-    const graphData: GraphData = [];
+    const nodes: GraphDataNode[] = [];
 
     // Serialize nodes
     for (const [id, info] of this.deviceGraph.getAllVertices()) {
@@ -170,9 +172,9 @@ export class DataGraph {
         id,
         connections: Array.from(this.deviceGraph.getNeighbors(id)),
       };
-      graphData.push(graphNode);
+      nodes.push(graphNode);
     }
-    return graphData;
+    return { nodes };
   }
 
   // Add a new device to the graph

--- a/src/types/graphs/datagraph.ts
+++ b/src/types/graphs/datagraph.ts
@@ -139,18 +139,7 @@ export class DataGraph {
 
     data.nodes.forEach((nodeData: GraphDataNode) => {
       console.log(nodeData);
-
-      let graphNode: GraphNode = nodeData;
-
-      if (isRouter(nodeData)) {
-        // If the node is a router, include the routing table
-        graphNode = {
-          ...nodeData,
-          routingTable: nodeData.routingTable || [], // Ensure routingTable exists
-        };
-      }
-
-      dataGraph.addDevice(nodeData.id, graphNode, []);
+      dataGraph.addDevice(nodeData.id, nodeData, []);
     });
 
     data.edges.forEach((edgeData: GraphEdge) => {

--- a/src/types/graphs/datagraph.ts
+++ b/src/types/graphs/datagraph.ts
@@ -70,6 +70,8 @@ export type GraphNode =
   | HostGraphNode
   | SwitchGraphNode;
 
+// STORAGE DATA TYPES
+
 export type GraphDataNode =
   | CommonDataNode
   | RouterDataNode
@@ -108,6 +110,17 @@ interface SwitchDataNode extends LinkDataNode {
   type: DeviceType.Switch;
 }
 
+interface EdgeTip {
+  id: DeviceId;
+  // TODO: uncomment this
+  // iface: number;
+}
+
+interface GraphEdge {
+  from: EdgeTip;
+  to: EdgeTip;
+}
+
 export type GraphData = GraphDataNode[];
 
 export interface NewDevice {
@@ -121,7 +134,7 @@ export interface NewDevice {
 
 export class DataGraph {
   // NOTE: we don't store data in edges yet
-  private deviceGraph = new Graph<GraphNode, unknown>();
+  private deviceGraph = new Graph<GraphNode, GraphEdge>();
   private idCounter: DeviceId = 1;
   private onChanges: (() => void)[] = [];
 
@@ -189,7 +202,8 @@ export class DataGraph {
     }
     this.deviceGraph.setVertex(idDevice, deviceInfo);
     connections.forEach((connectedId) => {
-      this.deviceGraph.setEdge(idDevice, connectedId);
+      const edge = { from: { id: idDevice }, to: { id: connectedId } };
+      this.deviceGraph.setEdge(idDevice, connectedId, edge);
     });
     if (this.idCounter <= idDevice) {
       this.idCounter = idDevice + 1;
@@ -220,7 +234,8 @@ export class DataGraph {
       );
       return;
     }
-    this.deviceGraph.setEdge(n1Id, n2Id);
+    const edge = { from: { id: n1Id }, to: { id: n2Id } };
+    this.deviceGraph.setEdge(n1Id, n2Id, edge);
 
     console.log(
       `Connection created between devices ID: ${n1Id} and ID: ${n2Id}`,

--- a/src/types/graphs/datagraph.ts
+++ b/src/types/graphs/datagraph.ts
@@ -187,13 +187,14 @@ export class DataGraph {
     return id;
   }
 
-  readdDevice(removedData: RemovedNodeData) {
+  readdDevice(removedData: RemovedNodeData): DeviceId {
     const { id, vertex, edges } = removedData;
     this.deviceGraph.setVertex(id, vertex);
     edges.forEach((edge) => {
       this.deviceGraph.setEdge(edge.from.id, edge.to.id, edge);
     });
     this.notifyChanges();
+    return id;
   }
 
   // Add a device to the graph

--- a/src/types/graphs/datagraph.ts
+++ b/src/types/graphs/datagraph.ts
@@ -5,14 +5,7 @@ import { Graph, VertexId } from "./graph";
 
 export type DeviceId = VertexId;
 
-interface CommonGraphNode {
-  id: DeviceId;
-  x: number;
-  y: number;
-  type: DeviceType;
-}
-
-interface LinkGraphNode extends CommonGraphNode {
+interface LinkGraphNode extends CommonDataNode {
   mac: string;
   arpTable: Map<string, string>;
 }
@@ -66,7 +59,7 @@ export function isLinkNode(node: GraphNode): node is LinkGraphNode {
 }
 
 export type GraphNode =
-  | CommonGraphNode
+  | CommonDataNode
   | RouterGraphNode
   | HostGraphNode
   | SwitchGraphNode;

--- a/src/types/graphs/datagraph.ts
+++ b/src/types/graphs/datagraph.ts
@@ -1,7 +1,7 @@
 import { RunningProgram } from "../../programs";
 import { DeviceType, Layer, layerFromType } from "../devices/device";
 import { layerIncluded } from "../devices/layer";
-import { Graph, VertexId } from "./graph";
+import { Graph, RemovedVertexData, VertexId } from "./graph";
 
 export type DeviceId = VertexId;
 
@@ -118,6 +118,8 @@ export interface GraphData {
   nodes: GraphDataNode[];
   edges: GraphEdge[];
 }
+
+export type RemovedNodeData = RemovedVertexData<GraphNode, GraphEdge>;
 
 export interface NewDevice {
   x: number;
@@ -280,15 +282,16 @@ export class DataGraph {
   }
 
   // Method to remove a device and all its connections
-  removeDevice(id: DeviceId): void {
+  removeDevice(id: DeviceId): RemovedNodeData | undefined {
     if (!this.deviceGraph.hasVertex(id)) {
       console.warn(`Device with ID ${id} does not exist in the graph.`);
       return;
     }
-    this.deviceGraph.removeVertex(id);
+    const removedData = this.deviceGraph.removeVertex(id);
     console.log(`Device with ID ${id} and its connections were removed.`);
     this.notifyChanges();
     this.regenerateAllRoutingTables();
+    return removedData;
   }
 
   // Method to remove a connection (edge) between two devices by their IDs

--- a/src/types/graphs/datagraph.ts
+++ b/src/types/graphs/datagraph.ts
@@ -143,35 +143,25 @@ export class DataGraph {
 
   static fromData(data: GraphData): DataGraph {
     const dataGraph = new DataGraph();
-    const connections = new Map<DeviceId, DeviceId[]>();
-    data.edges.forEach((edgeData: GraphEdge) => {
-      const addConnection = (from: DeviceId, to: DeviceId) => {
-        let conns = connections.get(from);
-        if (!conns) {
-          conns = [];
-        }
-        conns.push(to);
-        connections.set(from, conns);
-      };
-      addConnection(edgeData.from.id, edgeData.to.id);
-      addConnection(edgeData.to.id, edgeData.from.id);
-    });
+
     data.nodes.forEach((nodeData: GraphDataNode) => {
       console.log(nodeData);
 
       let graphNode: GraphNode = nodeData;
 
-      if (nodeData.type === DeviceType.Router) {
+      if (isRouter(nodeData)) {
         // If the node is a router, include the routing table
-        const routerNode = nodeData as RouterDataNode;
         graphNode = {
-          ...routerNode,
-          routingTable: routerNode.routingTable || [], // Ensure routingTable exists
+          ...nodeData,
+          routingTable: nodeData.routingTable || [], // Ensure routingTable exists
         };
       }
 
-      const conns = connections.get(nodeData.id) || [];
-      dataGraph.addDevice(nodeData.id, graphNode, conns);
+      dataGraph.addDevice(nodeData.id, graphNode, []);
+    });
+
+    data.edges.forEach((edgeData: GraphEdge) => {
+      dataGraph.deviceGraph.setEdge(edgeData.from.id, edgeData.to.id, edgeData);
     });
 
     return dataGraph;

--- a/src/types/graphs/graph.ts
+++ b/src/types/graphs/graph.ts
@@ -1,5 +1,11 @@
 export type VertexId = number;
 
+export interface RemovedVertexData<Vertex, Edge> {
+  id: VertexId;
+  vertex: Vertex;
+  edges: Map<VertexId, Edge>;
+}
+
 export class Graph<Vertex, Edge> {
   /**
    * Holds all of the Vertex data.
@@ -72,7 +78,8 @@ export class Graph<Vertex, Edge> {
     this.edges.get(otherId).set(id, edge);
   }
 
-  removeVertex(id: VertexId): void {
+  removeVertex(id: VertexId): RemovedVertexData<Vertex, Edge> | undefined {
+    const vertex = this.getVertex(id);
     if (!this.vertices.delete(id)) {
       return;
     }
@@ -82,14 +89,17 @@ export class Graph<Vertex, Edge> {
     edges.forEach((_, otherId) => {
       this.edges.get(otherId).delete(id);
     });
+    return { id, vertex, edges };
   }
 
-  removeEdge(id: VertexId, otherId: VertexId): void {
-    if (!this.hasVertex(id) || !this.hasVertex(otherId)) {
+  removeEdge(id: VertexId, otherId: VertexId): Edge | undefined {
+    const edge = this.getEdge(id, otherId);
+    if (!edge) {
       return;
     }
     this.edges.get(id).delete(otherId);
     this.edges.get(otherId).delete(id);
+    return edge;
   }
 
   clear() {

--- a/src/types/graphs/graph.ts
+++ b/src/types/graphs/graph.ts
@@ -64,7 +64,7 @@ export class Graph<Vertex, Edge> {
     }
   }
 
-  setEdge(id: VertexId, otherId: VertexId, edge: Edge = null): void {
+  setEdge(id: VertexId, otherId: VertexId, edge: Edge): void {
     if (!this.hasVertex(id) || !this.hasVertex(otherId)) {
       return;
     }

--- a/src/types/graphs/viewgraph.ts
+++ b/src/types/graphs/viewgraph.ts
@@ -62,7 +62,7 @@ export class ViewGraph {
       );
       return this.graph.getVertex(deviceData.id);
     }
-    const device = createDevice(deviceData, this, this.ctx);
+    const device = createDevice(deviceData.id, deviceData.node, this, this.ctx);
 
     this.graph.setVertex(device.id, device);
     this.viewport.addChild(device);

--- a/src/types/graphs/viewgraph.ts
+++ b/src/types/graphs/viewgraph.ts
@@ -1,6 +1,6 @@
 import { Device, NetworkDevice } from "./../devices";
 import { Edge, EdgeEdges } from "./../edge";
-import { DataGraph, DeviceId, GraphNode } from "./datagraph";
+import { DataGraph, DeviceId, GraphNode, RemovedNodeData } from "./datagraph";
 import { Viewport } from "../../graphics/viewport";
 import { Layer, layerIncluded } from "../devices/layer";
 import { createDevice } from "../devices/utils";
@@ -52,6 +52,7 @@ export class ViewGraph {
   }
 
   // Add a device to the graph
+  // TODO: make this add device to datagraph
   private addDevice(id: DeviceId, node: GraphNode): Device {
     if (this.graph.hasVertex(id)) {
       console.warn(`Device with ID ${id} already exists in the graph.`);
@@ -201,7 +202,7 @@ export class ViewGraph {
   }
 
   // Method to remove a device and its connections (edges)
-  removeDevice(id: DeviceId) {
+  removeDevice(id: DeviceId): RemovedNodeData | undefined {
     const device = this.graph.getVertex(id);
 
     if (!device) {
@@ -220,9 +221,10 @@ export class ViewGraph {
     this.viewport.removeChild(device);
 
     // Finally, remove the device from the datagraph
-    this.datagraph.removeDevice(id);
+    const removedData = this.datagraph.removeDevice(id);
 
     console.log(`Device with ID ${id} removed from view.`);
+    return removedData;
   }
 
   // Method to remove a specific edge by its ID

--- a/src/types/graphs/viewgraph.ts
+++ b/src/types/graphs/viewgraph.ts
@@ -3,7 +3,7 @@ import { Edge, EdgeEdges } from "./../edge";
 import { DataGraph, DeviceId, GraphNode } from "./datagraph";
 import { Viewport } from "../../graphics/viewport";
 import { Layer, layerIncluded } from "../devices/layer";
-import { CreateDevice, createDevice } from "../devices/utils";
+import { createDevice } from "../devices/utils";
 import { layerFromType } from "../devices/device";
 import { IpAddress } from "../../packets/ip";
 import { GlobalContext } from "../../context";
@@ -32,7 +32,6 @@ export class ViewGraph {
 
     for (const [deviceId, graphNode] of this.datagraph.getDevices()) {
       if (layerIncluded(layerFromType(graphNode.type), this.layer)) {
-        const connections = this.datagraph.getConnections(deviceId);
         this.createDevice(deviceId, graphNode);
 
         this.computeLayerConnections(deviceId, allConnections);
@@ -42,14 +41,14 @@ export class ViewGraph {
     console.log("Finished constructing ViewGraph");
   }
 
-  addDevice(deviceData: CreateDevice) {
-    const device = this.createDevice(deviceData.id, deviceData.node);
-    if (deviceData.connections.length !== 0) {
-      const connections = new Map<string, EdgePair>();
-      this.computeLayerConnections(deviceData.id, connections);
+  loadDevice(deviceId: DeviceId) {
+    const node = this.datagraph.getDevice(deviceId);
+    const device = this.createDevice(deviceId, node);
 
-      this.addConnections(connections);
-    }
+    // load connections
+    const connections = new Map<string, EdgePair>();
+    this.computeLayerConnections(deviceId, connections);
+    this.addConnections(connections);
     return device;
   }
 

--- a/src/types/graphs/viewgraph.ts
+++ b/src/types/graphs/viewgraph.ts
@@ -226,12 +226,12 @@ export class ViewGraph {
   }
 
   // Method to remove a specific edge by its ID
-  removeEdge(n1Id: DeviceId, n2Id: DeviceId) {
+  removeEdge(n1Id: DeviceId, n2Id: DeviceId): boolean {
     const edge = this.graph.getEdge(n1Id, n2Id);
 
     if (!edge) {
       console.warn(`Edge with ID ${n1Id},${n2Id} does not exist in the graph.`);
-      return;
+      return false;
     }
 
     // Remove connection in DataGraph
@@ -244,7 +244,7 @@ export class ViewGraph {
 
     if (!(device1 && device2)) {
       console.warn("At least one device in connection does not exist");
-      return;
+      return false;
     }
 
     // Remove the edge from the viewport
@@ -256,6 +256,7 @@ export class ViewGraph {
     console.log(
       `Edge with ID ${n1Id},${n2Id} successfully removed from ViewGraph.`,
     );
+    return true;
   }
 
   getViewport() {

--- a/src/types/graphs/viewgraph.ts
+++ b/src/types/graphs/viewgraph.ts
@@ -1,6 +1,6 @@
 import { Device, NetworkDevice } from "./../devices";
 import { Edge, EdgeEdges } from "./../edge";
-import { DataGraph, DeviceId } from "./datagraph";
+import { DataGraph, DeviceId, GraphNode } from "./datagraph";
 import { Viewport } from "../../graphics/viewport";
 import { Layer, layerIncluded } from "../devices/layer";
 import { CreateDevice, createDevice } from "../devices/utils";
@@ -33,8 +33,7 @@ export class ViewGraph {
     for (const [deviceId, graphNode] of this.datagraph.getDevices()) {
       if (layerIncluded(layerFromType(graphNode.type), this.layer)) {
         const connections = this.datagraph.getConnections(deviceId);
-        const deviceInfo = { id: deviceId, node: graphNode, connections };
-        this.createDevice(deviceInfo);
+        this.createDevice(deviceId, graphNode);
 
         this.computeLayerConnections(deviceId, allConnections);
       }
@@ -44,7 +43,7 @@ export class ViewGraph {
   }
 
   addDevice(deviceData: CreateDevice) {
-    const device = this.createDevice(deviceData);
+    const device = this.createDevice(deviceData.id, deviceData.node);
     if (deviceData.connections.length !== 0) {
       const connections = new Set<EdgeId>();
       this.computeLayerConnections(deviceData.id, connections);
@@ -55,19 +54,17 @@ export class ViewGraph {
   }
 
   // Add a device to the graph
-  private createDevice(deviceData: CreateDevice): Device {
-    if (this.graph.hasVertex(deviceData.id)) {
-      console.warn(
-        `Device with ID ${deviceData.id} already exists in the graph.`,
-      );
-      return this.graph.getVertex(deviceData.id);
+  private createDevice(id: DeviceId, node: GraphNode): Device {
+    if (this.graph.hasVertex(id)) {
+      console.warn(`Device with ID ${id} already exists in the graph.`);
+      return this.graph.getVertex(id);
     }
-    const device = createDevice(deviceData.id, deviceData.node, this, this.ctx);
+    const device = createDevice(id, node, this, this.ctx);
 
     this.graph.setVertex(device.id, device);
     this.viewport.addChild(device);
     console.log(`Device added with ID ${device.id}`);
-    return this.graph.getVertex(deviceData.id);
+    return this.graph.getVertex(id);
   }
 
   private addConnections(connections: Set<EdgeId>) {

--- a/src/types/graphs/viewgraph.ts
+++ b/src/types/graphs/viewgraph.ts
@@ -228,10 +228,16 @@ export class ViewGraph {
 
   // Method to remove a specific edge by its ID
   removeEdge(n1Id: DeviceId, n2Id: DeviceId): boolean {
-    const edge = this.graph.getEdge(n1Id, n2Id);
+    const datagraphEdge = this.datagraph.getConnection(n1Id, n2Id);
 
+    if (!datagraphEdge) {
+      console.warn(`Edge ${n1Id},${n2Id} is not in the datagraph`);
+      return false;
+    }
+
+    const edge = this.graph.getEdge(n1Id, n2Id);
     if (!edge) {
-      console.warn(`Edge with ID ${n1Id},${n2Id} does not exist in the graph.`);
+      console.warn(`Edge ${n1Id},${n2Id} is not in the viewgraph.`);
       return false;
     }
 

--- a/src/types/graphs/viewgraph.ts
+++ b/src/types/graphs/viewgraph.ts
@@ -52,7 +52,6 @@ export class ViewGraph {
   }
 
   // Add a device to the graph
-  // TODO: make this add device to datagraph
   private addDevice(id: DeviceId, node: GraphNode): Device {
     if (this.graph.hasVertex(id)) {
       console.warn(`Device with ID ${id} already exists in the graph.`);

--- a/src/types/graphs/viewgraph.ts
+++ b/src/types/graphs/viewgraph.ts
@@ -32,8 +32,7 @@ export class ViewGraph {
 
     for (const [deviceId, graphNode] of this.datagraph.getDevices()) {
       if (layerIncluded(layerFromType(graphNode.type), this.layer)) {
-        this.createDevice(deviceId, graphNode);
-
+        this.addDevice(deviceId, graphNode);
         this.computeLayerConnections(deviceId, allConnections);
       }
     }
@@ -43,7 +42,7 @@ export class ViewGraph {
 
   loadDevice(deviceId: DeviceId) {
     const node = this.datagraph.getDevice(deviceId);
-    const device = this.createDevice(deviceId, node);
+    const device = this.addDevice(deviceId, node);
 
     // load connections
     const connections = new Map<string, EdgePair>();
@@ -53,7 +52,7 @@ export class ViewGraph {
   }
 
   // Add a device to the graph
-  private createDevice(id: DeviceId, node: GraphNode): Device {
+  private addDevice(id: DeviceId, node: GraphNode): Device {
     if (this.graph.hasVertex(id)) {
       console.warn(`Device with ID ${id} already exists in the graph.`);
       return this.graph.getVertex(id);

--- a/src/types/undo-redo/moves/addRemoveDevice.ts
+++ b/src/types/undo-redo/moves/addRemoveDevice.ts
@@ -1,10 +1,5 @@
 import { Layer } from "../../devices/device";
-import {
-  DeviceId,
-  GraphNode,
-  NewDevice,
-  RemovedNodeData,
-} from "../../graphs/datagraph";
+import { DeviceId, NewDevice, RemovedNodeData } from "../../graphs/datagraph";
 import { ViewGraph } from "../../graphs/viewgraph";
 import { selectElement } from "../../viewportManager";
 import { BaseMove } from "./move";

--- a/src/types/undo-redo/moves/addRemoveDevice.ts
+++ b/src/types/undo-redo/moves/addRemoveDevice.ts
@@ -28,35 +28,37 @@ export abstract class AddRemoveDeviceMove extends BaseMove {
     this.adjustLayer(viewgraph);
 
     viewgraph.loadDevice(this.data.id);
+    return true;
   }
 
   removeDevice(viewgraph: ViewGraph) {
     this.adjustLayer(viewgraph);
     const device = viewgraph.getDevice(this.data.id);
     if (device == undefined) {
-      throw new Error(`Device with ID ${this.data.id} not found.`);
+      return false;
     }
     device.delete();
+    return true;
   }
 }
 
 // "Move" is here because it conflicts with AddDevice from viewportManager
 export class AddDeviceMove extends AddRemoveDeviceMove {
-  undo(viewgraph: ViewGraph): void {
-    this.removeDevice(viewgraph);
+  undo(viewgraph: ViewGraph): boolean {
+    return this.removeDevice(viewgraph);
   }
 
-  redo(viewgraph: ViewGraph): void {
-    this.addDevice(viewgraph);
+  redo(viewgraph: ViewGraph): boolean {
+    return this.addDevice(viewgraph);
   }
 }
 
 export class RemoveDeviceMove extends AddRemoveDeviceMove {
-  undo(viewgraph: ViewGraph): void {
-    this.addDevice(viewgraph);
+  undo(viewgraph: ViewGraph): boolean {
+    return this.addDevice(viewgraph);
   }
 
-  redo(viewgraph: ViewGraph): void {
-    this.removeDevice(viewgraph);
+  redo(viewgraph: ViewGraph): boolean {
+    return this.removeDevice(viewgraph);
   }
 }

--- a/src/types/undo-redo/moves/addRemoveDevice.ts
+++ b/src/types/undo-redo/moves/addRemoveDevice.ts
@@ -33,12 +33,7 @@ export abstract class AddRemoveDeviceMove extends BaseMove {
 
     // It was removed before
     if (this.removedData) {
-      // Add the device to the datagraph and the viewgraph
-      const deviceInfo = structuredClone(this.removedData.vertex);
-      // Clone array to avoid modifying the original
-      const connections = Array.from(this.removedData.edges.keys());
-
-      datagraph.addDevice(deviceInfo.id, deviceInfo, connections);
+      datagraph.readdDevice(this.removedData);
       datagraph.regenerateAllRoutingTables();
     } else {
       // Add the new device

--- a/src/types/undo-redo/moves/addRemoveDevice.ts
+++ b/src/types/undo-redo/moves/addRemoveDevice.ts
@@ -12,13 +12,20 @@ export interface DeviceData {
 
 // Superclass for AddDeviceMove and RemoveDeviceMove
 export abstract class AddRemoveDeviceMove extends BaseMove {
+  // TODO: reduce duplicate data
+  id: DeviceId;
   data: DeviceData;
 
-  constructor(layer: Layer, data: DeviceData) {
-    // NOTE: we have to deep-copy the data to stop the data from
-    // being modified by the original
+  // TODO: simplify
+  constructor(layer: Layer, options: { data?: DeviceData; id?: DeviceId }) {
     super(layer);
-    this.data = structuredClone(data);
+    if (options.id == undefined) {
+      // NOTE: we have to deep-copy the data to stop the data from
+      // being modified by the original
+      this.data = structuredClone(options.data);
+    } else {
+      this.id = options.id;
+    }
   }
 
   addDevice(viewgraph: ViewGraph) {
@@ -27,6 +34,7 @@ export abstract class AddRemoveDeviceMove extends BaseMove {
     // If ID was unspecified, it means it's a new device
     if (this.data.id == undefined) {
       const id = datagraph.addNewDevice(this.data.node);
+      this.id = id;
       this.data.id = id;
       this.data.connections = [];
     } else {
@@ -46,10 +54,11 @@ export abstract class AddRemoveDeviceMove extends BaseMove {
 
   removeDevice(viewgraph: ViewGraph) {
     this.adjustLayer(viewgraph);
-    const device = viewgraph.getDevice(this.data.id);
+    const device = viewgraph.getDevice(this.id);
     if (device == undefined) {
       return false;
     }
+    this.data = device.getCreateDevice();
     // This also deselects the element
     device.delete();
     return true;
@@ -58,6 +67,10 @@ export abstract class AddRemoveDeviceMove extends BaseMove {
 
 // "Move" is here because it conflicts with AddDevice from viewportManager
 export class AddDeviceMove extends AddRemoveDeviceMove {
+  constructor(layer: Layer, data: DeviceData) {
+    super(layer, { data });
+  }
+
   undo(viewgraph: ViewGraph): boolean {
     return this.removeDevice(viewgraph);
   }
@@ -68,6 +81,10 @@ export class AddDeviceMove extends AddRemoveDeviceMove {
 }
 
 export class RemoveDeviceMove extends AddRemoveDeviceMove {
+  constructor(layer: Layer, id: DeviceId) {
+    super(layer, { id });
+  }
+
   undo(viewgraph: ViewGraph): boolean {
     return this.addDevice(viewgraph);
   }

--- a/src/types/undo-redo/moves/addRemoveDevice.ts
+++ b/src/types/undo-redo/moves/addRemoveDevice.ts
@@ -50,6 +50,7 @@ export abstract class AddRemoveDeviceMove extends BaseMove {
     if (device == undefined) {
       return false;
     }
+    // This also deselects the element
     device.delete();
     return true;
   }

--- a/src/types/undo-redo/moves/addRemoveDevice.ts
+++ b/src/types/undo-redo/moves/addRemoveDevice.ts
@@ -27,8 +27,7 @@ export abstract class AddRemoveDeviceMove extends BaseMove {
 
     this.adjustLayer(viewgraph);
 
-    const deviceData = structuredClone(this.data);
-    viewgraph.addDevice(deviceData);
+    viewgraph.loadDevice(this.data.id);
   }
 
   removeDevice(viewgraph: ViewGraph) {

--- a/src/types/undo-redo/moves/addRemoveDevice.ts
+++ b/src/types/undo-redo/moves/addRemoveDevice.ts
@@ -10,8 +10,42 @@ export interface DeviceData {
   connections?: DeviceId[];
 }
 
-// Superclass for AddDeviceMove and RemoveDeviceMove
-export abstract class AddRemoveDeviceMove extends BaseMove {
+function addDevice(viewgraph: ViewGraph, data: DeviceData) {
+  const datagraph = viewgraph.getDataGraph();
+
+  // If ID was unspecified, it means it's a new device
+  if (data.id == undefined) {
+    const id = datagraph.addNewDevice(data.node);
+    data.id = id;
+    data.connections = [];
+  } else {
+    // Add the device to the datagraph and the viewgraph
+    const deviceInfo = structuredClone(data.node);
+    // Clone array to avoid modifying the original
+    const connections = Array.from(data.connections);
+
+    datagraph.addDevice(data.id, deviceInfo, connections);
+    datagraph.regenerateAllRoutingTables();
+  }
+  this.adjustLayer(viewgraph);
+  viewgraph.loadDevice(data.id);
+  selectElement(viewgraph.getDevice(data.id));
+  return true;
+}
+
+function removeDevice(viewgraph: ViewGraph, data: DeviceData) {
+  this.adjustLayer(viewgraph);
+  const device = viewgraph.getDevice(data.id);
+  if (device == undefined) {
+    return false;
+  }
+  // This also deselects the element
+  device.delete();
+  return true;
+}
+
+// "Move" is here because it conflicts with AddDevice from viewportManager
+export class AddDeviceMove extends BaseMove {
   data: DeviceData;
 
   constructor(layer: Layer, data: DeviceData) {
@@ -21,58 +55,30 @@ export abstract class AddRemoveDeviceMove extends BaseMove {
     this.data = structuredClone(data);
   }
 
-  addDevice(viewgraph: ViewGraph) {
-    const datagraph = viewgraph.getDataGraph();
-
-    // If ID was unspecified, it means it's a new device
-    if (this.data.id == undefined) {
-      const id = datagraph.addNewDevice(this.data.node);
-      this.data.id = id;
-      this.data.connections = [];
-    } else {
-      // Add the device to the datagraph and the viewgraph
-      const deviceInfo = structuredClone(this.data.node);
-      // Clone array to avoid modifying the original
-      const connections = Array.from(this.data.connections);
-
-      datagraph.addDevice(this.data.id, deviceInfo, connections);
-      datagraph.regenerateAllRoutingTables();
-    }
-    this.adjustLayer(viewgraph);
-    viewgraph.loadDevice(this.data.id);
-    selectElement(viewgraph.getDevice(this.data.id));
-    return true;
-  }
-
-  removeDevice(viewgraph: ViewGraph) {
-    this.adjustLayer(viewgraph);
-    const device = viewgraph.getDevice(this.data.id);
-    if (device == undefined) {
-      return false;
-    }
-    // This also deselects the element
-    device.delete();
-    return true;
-  }
-}
-
-// "Move" is here because it conflicts with AddDevice from viewportManager
-export class AddDeviceMove extends AddRemoveDeviceMove {
   undo(viewgraph: ViewGraph): boolean {
-    return this.removeDevice(viewgraph);
+    return removeDevice(viewgraph, this.data);
   }
 
   redo(viewgraph: ViewGraph): boolean {
-    return this.addDevice(viewgraph);
+    return addDevice(viewgraph, this.data);
   }
 }
 
-export class RemoveDeviceMove extends AddRemoveDeviceMove {
+export class RemoveDeviceMove extends BaseMove {
+  data: DeviceData;
+
+  constructor(layer: Layer, data: DeviceData) {
+    // NOTE: we have to deep-copy the data to stop the data from
+    // being modified by the original
+    super(layer);
+    this.data = structuredClone(data);
+  }
+
   undo(viewgraph: ViewGraph): boolean {
-    return this.addDevice(viewgraph);
+    return addDevice(viewgraph, this.data);
   }
 
   redo(viewgraph: ViewGraph): boolean {
-    return this.removeDevice(viewgraph);
+    return removeDevice(viewgraph, this.data);
   }
 }

--- a/src/types/undo-redo/moves/addRemoveDevice.ts
+++ b/src/types/undo-redo/moves/addRemoveDevice.ts
@@ -10,75 +10,69 @@ export interface DeviceData {
   connections?: DeviceId[];
 }
 
-function addDevice(viewgraph: ViewGraph, data: DeviceData) {
-  const datagraph = viewgraph.getDataGraph();
+// Superclass for AddDeviceMove and RemoveDeviceMove
+export abstract class AddRemoveDeviceMove extends BaseMove {
+  data: DeviceData;
 
-  // If ID was unspecified, it means it's a new device
-  if (data.id == undefined) {
-    const id = datagraph.addNewDevice(data.node);
-    data.id = id;
-    data.connections = [];
-  } else {
-    // Add the device to the datagraph and the viewgraph
-    const deviceInfo = structuredClone(data.node);
-    // Clone array to avoid modifying the original
-    const connections = Array.from(data.connections);
-
-    datagraph.addDevice(data.id, deviceInfo, connections);
-    datagraph.regenerateAllRoutingTables();
+  constructor(layer: Layer, data: DeviceData) {
+    // NOTE: we have to deep-copy the data to stop the data from
+    // being modified by the original
+    super(layer);
+    this.data = structuredClone(data);
   }
-  this.adjustLayer(viewgraph);
-  viewgraph.loadDevice(data.id);
-  selectElement(viewgraph.getDevice(data.id));
-  return true;
-}
 
-function removeDevice(viewgraph: ViewGraph, data: DeviceData) {
-  this.adjustLayer(viewgraph);
-  const device = viewgraph.getDevice(data.id);
-  if (device == undefined) {
-    return false;
+  addDevice(viewgraph: ViewGraph) {
+    const datagraph = viewgraph.getDataGraph();
+
+    // If ID was unspecified, it means it's a new device
+    if (this.data.id == undefined) {
+      const id = datagraph.addNewDevice(this.data.node);
+      this.data.id = id;
+      this.data.connections = [];
+    } else {
+      // Add the device to the datagraph and the viewgraph
+      const deviceInfo = structuredClone(this.data.node);
+      // Clone array to avoid modifying the original
+      const connections = Array.from(this.data.connections);
+
+      datagraph.addDevice(this.data.id, deviceInfo, connections);
+      datagraph.regenerateAllRoutingTables();
+    }
+    this.adjustLayer(viewgraph);
+    viewgraph.loadDevice(this.data.id);
+    selectElement(viewgraph.getDevice(this.data.id));
+    return true;
   }
-  // This also deselects the element
-  device.delete();
-  return true;
+
+  removeDevice(viewgraph: ViewGraph) {
+    this.adjustLayer(viewgraph);
+    const device = viewgraph.getDevice(this.data.id);
+    if (device == undefined) {
+      return false;
+    }
+    // This also deselects the element
+    device.delete();
+    return true;
+  }
 }
 
 // "Move" is here because it conflicts with AddDevice from viewportManager
-export class AddDeviceMove extends BaseMove {
-  data: DeviceData;
-
-  constructor(layer: Layer, data: DeviceData) {
-    // NOTE: we have to deep-copy the data to stop the data from
-    // being modified by the original
-    super(layer);
-    this.data = structuredClone(data);
-  }
-
+export class AddDeviceMove extends AddRemoveDeviceMove {
   undo(viewgraph: ViewGraph): boolean {
-    return removeDevice(viewgraph, this.data);
+    return this.removeDevice(viewgraph);
   }
 
   redo(viewgraph: ViewGraph): boolean {
-    return addDevice(viewgraph, this.data);
+    return this.addDevice(viewgraph);
   }
 }
 
-export class RemoveDeviceMove extends BaseMove {
-  data: DeviceData;
-
-  constructor(layer: Layer, data: DeviceData) {
-    // NOTE: we have to deep-copy the data to stop the data from
-    // being modified by the original
-    super(layer);
-    this.data = structuredClone(data);
-  }
-
+export class RemoveDeviceMove extends AddRemoveDeviceMove {
   undo(viewgraph: ViewGraph): boolean {
-    return addDevice(viewgraph, this.data);
+    return this.addDevice(viewgraph);
   }
 
   redo(viewgraph: ViewGraph): boolean {
-    return removeDevice(viewgraph, this.data);
+    return this.removeDevice(viewgraph);
   }
 }

--- a/src/types/undo-redo/moves/addRemoveEdge.ts
+++ b/src/types/undo-redo/moves/addRemoveEdge.ts
@@ -2,6 +2,7 @@ import { Layer } from "../../devices/layer";
 import { EdgeEdges } from "../../edge";
 import { DeviceId, RoutingTableEntry } from "../../graphs/datagraph";
 import { ViewGraph } from "../../graphs/viewgraph";
+import { deselectElement } from "../../viewportManager";
 import { BaseMove } from "./move";
 
 export abstract class AddRemoveEdgeMove extends BaseMove {
@@ -30,6 +31,8 @@ export abstract class AddRemoveEdgeMove extends BaseMove {
   removeEdge(viewgraph: ViewGraph) {
     this.adjustLayer(viewgraph);
     const { n1, n2 } = this.connectedNodes;
+    // Deselect to avoid showing the information of the deleted edge
+    deselectElement();
     return viewgraph.removeEdge(n1, n2);
   }
 }

--- a/src/types/undo-redo/moves/addRemoveEdge.ts
+++ b/src/types/undo-redo/moves/addRemoveEdge.ts
@@ -31,9 +31,10 @@ export abstract class AddRemoveEdgeMove extends BaseMove {
   removeEdge(viewgraph: ViewGraph) {
     this.adjustLayer(viewgraph);
     const { n1, n2 } = this.connectedNodes;
-    // Deselect to avoid showing the information of the deleted edge
     const ok = viewgraph.removeEdge(n1, n2);
+    // Avoid deselecting in case of failure, since it's probably a virtual edge
     if (ok) {
+      // Deselect to avoid showing the information of the deleted edge
       deselectElement();
     }
     return ok;

--- a/src/types/undo-redo/moves/addRemoveEdge.ts
+++ b/src/types/undo-redo/moves/addRemoveEdge.ts
@@ -21,25 +21,26 @@ export abstract class AddRemoveEdgeMove extends BaseMove {
     const device2 = viewgraph.getDevice(n2);
     if (!device1 || !device2) {
       console.warn("Edge's devices not found in viewgraph");
-      return;
+      return false;
     }
     viewgraph.addEdge(n1, n2);
+    return true;
   }
 
   removeEdge(viewgraph: ViewGraph) {
     this.adjustLayer(viewgraph);
     const { n1, n2 } = this.connectedNodes;
-    viewgraph.removeEdge(n1, n2);
+    return viewgraph.removeEdge(n1, n2);
   }
 }
 
 export class AddEdgeMove extends AddRemoveEdgeMove {
-  undo(viewgraph: ViewGraph): void {
-    this.removeEdge(viewgraph);
+  undo(viewgraph: ViewGraph): boolean {
+    return this.removeEdge(viewgraph);
   }
 
-  redo(viewgraph: ViewGraph): void {
-    this.addEdge(viewgraph);
+  redo(viewgraph: ViewGraph): boolean {
+    return this.addEdge(viewgraph);
   }
 }
 
@@ -55,16 +56,19 @@ export class RemoveEdgeMove extends AddRemoveEdgeMove {
     this.storedRoutingTables = storedRoutingTables;
   }
 
-  undo(viewgraph: ViewGraph): void {
-    this.addEdge(viewgraph);
+  undo(viewgraph: ViewGraph): boolean {
+    if (!this.addEdge(viewgraph)) {
+      return false;
+    }
 
-    // Restaurar las tablas de enrutamiento guardadas
+    // Restore stored routing tables
     this.storedRoutingTables.forEach((table, deviceId) => {
       viewgraph.getDataGraph().setRoutingTable(deviceId, table);
     });
+    return true;
   }
 
-  redo(viewgraph: ViewGraph): void {
-    this.removeEdge(viewgraph);
+  redo(viewgraph: ViewGraph): boolean {
+    return this.removeEdge(viewgraph);
   }
 }

--- a/src/types/undo-redo/moves/addRemoveEdge.ts
+++ b/src/types/undo-redo/moves/addRemoveEdge.ts
@@ -32,8 +32,11 @@ export abstract class AddRemoveEdgeMove extends BaseMove {
     this.adjustLayer(viewgraph);
     const { n1, n2 } = this.connectedNodes;
     // Deselect to avoid showing the information of the deleted edge
-    deselectElement();
-    return viewgraph.removeEdge(n1, n2);
+    const ok = viewgraph.removeEdge(n1, n2);
+    if (ok) {
+      deselectElement();
+    }
+    return ok;
   }
 }
 

--- a/src/types/undo-redo/moves/dragDevice.ts
+++ b/src/types/undo-redo/moves/dragDevice.ts
@@ -26,19 +26,20 @@ export class DragDeviceMove extends BaseMove {
 
     const device = viewgraph.getDevice(this.did);
     if (!device) {
-      throw new Error(`Device with ID ${this.did} not found in viewgraph.`);
+      return false;
     }
 
     device.x = position.x;
     device.y = position.y;
     viewgraph.deviceMoved(this.did);
+    return true;
   }
 
-  undo(viewgraph: ViewGraph): void {
-    this.moveDevice(viewgraph, this.startPosition);
+  undo(viewgraph: ViewGraph): boolean {
+    return this.moveDevice(viewgraph, this.startPosition);
   }
 
-  redo(viewgraph: ViewGraph): void {
-    this.moveDevice(viewgraph, this.endPosition);
+  redo(viewgraph: ViewGraph): boolean {
+    return this.moveDevice(viewgraph, this.endPosition);
   }
 }

--- a/src/types/undo-redo/moves/move.ts
+++ b/src/types/undo-redo/moves/move.ts
@@ -2,7 +2,16 @@ import { Layer, layerIncluded } from "../../devices/layer";
 import { ViewGraph } from "../../graphs/viewgraph";
 
 export interface Move {
+  /**
+   * Undoes the move.
+   * @returns true if the move was successfully undone, false otherwise.
+   */
   undo(viewgraph: ViewGraph): void;
+
+  /**
+   * Performs the move.
+   * @returns true if the move was successfully done, false otherwise.
+   */
   redo(viewgraph: ViewGraph): void;
 }
 
@@ -15,7 +24,7 @@ export abstract class BaseMove implements Move {
     this.layerInMove = layer;
   }
 
-  adjustLayer(viewgraph: ViewGraph) {
+  protected adjustLayer(viewgraph: ViewGraph) {
     if (!layerIncluded(this.layerInMove, viewgraph.getLayer())) {
       viewgraph.changeCurrLayer(this.layerInMove);
     }

--- a/src/types/undo-redo/moves/move.ts
+++ b/src/types/undo-redo/moves/move.ts
@@ -6,19 +6,19 @@ export interface Move {
    * Undoes the move.
    * @returns true if the move was successfully undone, false otherwise.
    */
-  undo(viewgraph: ViewGraph): void;
+  undo(viewgraph: ViewGraph): boolean;
 
   /**
    * Performs the move.
    * @returns true if the move was successfully done, false otherwise.
    */
-  redo(viewgraph: ViewGraph): void;
+  redo(viewgraph: ViewGraph): boolean;
 }
 
 export abstract class BaseMove implements Move {
   layerInMove: Layer;
-  abstract undo(viewgraph: ViewGraph): void;
-  abstract redo(viewgraph: ViewGraph): void;
+  abstract undo(viewgraph: ViewGraph): boolean;
+  abstract redo(viewgraph: ViewGraph): boolean;
 
   constructor(layer: Layer) {
     this.layerInMove = layer;

--- a/src/types/undo-redo/undoRedoManager.ts
+++ b/src/types/undo-redo/undoRedoManager.ts
@@ -11,12 +11,10 @@ export class UndoRedoManager {
     this.listeners.forEach((listener) => listener());
   }
 
-  push(move: Move) {
-    if (this.redoBuf.length != 0) {
-      this.redoBuf = [];
-    }
-    this.undoBuf.push(move);
-    this.notifyListeners();
+  push(viewgraph: ViewGraph, move: Move) {
+    this.redoBuf = [move];
+    // TODO: verify the move is valid
+    this.redo(viewgraph);
   }
 
   undo(viewgraph: ViewGraph) {

--- a/src/types/undo-redo/undoRedoManager.ts
+++ b/src/types/undo-redo/undoRedoManager.ts
@@ -51,7 +51,7 @@ export class UndoRedoManager {
     return this.redoBuf.length != 0;
   }
 
-  suscribe(listener: () => void) {
+  subscribe(listener: () => void) {
     this.listeners.push(listener);
   }
 

--- a/src/types/undo-redo/undoRedoManager.ts
+++ b/src/types/undo-redo/undoRedoManager.ts
@@ -24,14 +24,15 @@ export class UndoRedoManager {
    * Undoes the last move in the undo buffer.
    */
   undo(viewgraph: ViewGraph) {
-    if (this.undoBuf.length != 0) {
-      const move = this.undoBuf.pop();
-      // Discard the move if it was unsuccessful
-      if (move.undo(viewgraph)) {
-        this.redoBuf.push(move);
-      } else {
-        console.error("Undo failed.");
-      }
+    if (!this.canUndo()) {
+      return;
+    }
+    const move = this.undoBuf.pop();
+    // Discard the move if it was unsuccessful
+    if (move.undo(viewgraph)) {
+      this.redoBuf.push(move);
+    } else {
+      console.error("Undo failed.");
     }
     this.notifyListeners();
   }
@@ -40,24 +41,25 @@ export class UndoRedoManager {
    * Redoes the last move in the redo buffer.
    */
   redo(viewgraph: ViewGraph) {
-    if (this.redoBuf.length != 0) {
-      const move = this.redoBuf.pop();
-      // Discard the move if it was unsuccessful
-      if (move.redo(viewgraph)) {
-        this.undoBuf.push(move);
-      } else {
-        console.error("Move failed.");
-      }
+    if (!this.canRedo()) {
+      return;
+    }
+    const move = this.redoBuf.pop();
+    // Discard the move if it was unsuccessful
+    if (move.redo(viewgraph)) {
+      this.undoBuf.push(move);
+    } else {
+      console.error("Move failed.");
     }
     this.notifyListeners();
   }
 
   canUndo(): boolean {
-    return this.undoBuf.length != 0;
+    return this.undoBuf.length !== 0;
   }
 
   canRedo(): boolean {
-    return this.redoBuf.length != 0;
+    return this.redoBuf.length !== 0;
   }
 
   subscribe(listener: () => void) {

--- a/src/types/undo-redo/undoRedoManager.ts
+++ b/src/types/undo-redo/undoRedoManager.ts
@@ -11,8 +11,13 @@ export class UndoRedoManager {
   }
 
   push(viewgraph: ViewGraph, move: Move) {
-    this.redoBuf = [move];
-    this.redo(viewgraph);
+    if (move.redo(viewgraph)) {
+      this.undoBuf.push(move);
+      this.redoBuf = [];
+      this.notifyListeners();
+    } else {
+      console.warn("Move push failed.");
+    }
   }
 
   /**

--- a/src/types/undo-redo/undoRedoManager.ts
+++ b/src/types/undo-redo/undoRedoManager.ts
@@ -13,14 +13,16 @@ export class UndoRedoManager {
   /**
    * Performs a move and pushes it to the undo buffer.
    */
-  push(viewgraph: ViewGraph, move: Move) {
-    if (move.redo(viewgraph)) {
+  push(viewgraph: ViewGraph, move: Move): boolean {
+    const ok = move.redo(viewgraph);
+    if (ok) {
       this.undoBuf.push(move);
       this.redoBuf = [];
       this.notifyListeners();
     } else {
       console.warn("Move push failed.");
     }
+    return ok;
   }
 
   /**

--- a/src/types/undo-redo/undoRedoManager.ts
+++ b/src/types/undo-redo/undoRedoManager.ts
@@ -13,15 +13,21 @@ export class UndoRedoManager {
 
   push(viewgraph: ViewGraph, move: Move) {
     this.redoBuf = [move];
-    // TODO: verify the move is valid
     this.redo(viewgraph);
   }
 
+  /**
+   * Undoes the last move in the undo buffer.
+   */
   undo(viewgraph: ViewGraph) {
     if (this.undoBuf.length != 0) {
       const move = this.undoBuf.pop();
-      move.undo(viewgraph);
-      this.redoBuf.push(move);
+      // Discard the move if it was unsuccessful
+      if (move.undo(viewgraph)) {
+        this.redoBuf.push(move);
+      } else {
+        console.error("Undo failed.");
+      }
     }
     this.notifyListeners();
     console.log(this.redoBuf);
@@ -29,11 +35,18 @@ export class UndoRedoManager {
     deselectElement();
   }
 
+  /**
+   * Redoes the last move in the redo buffer.
+   */
   redo(viewgraph: ViewGraph) {
     if (this.redoBuf.length != 0) {
       const move = this.redoBuf.pop();
-      move.redo(viewgraph);
-      this.undoBuf.push(move);
+      // Discard the move if it was unsuccessful
+      if (move.redo(viewgraph)) {
+        this.undoBuf.push(move);
+      } else {
+        console.error("Move failed.");
+      }
     }
     this.notifyListeners();
     console.log(this.redoBuf);

--- a/src/types/undo-redo/undoRedoManager.ts
+++ b/src/types/undo-redo/undoRedoManager.ts
@@ -10,6 +10,9 @@ export class UndoRedoManager {
     this.listeners.forEach((listener) => listener());
   }
 
+  /**
+   * Performs a move and pushes it to the undo buffer.
+   */
   push(viewgraph: ViewGraph, move: Move) {
     if (move.redo(viewgraph)) {
       this.undoBuf.push(move);

--- a/src/types/undo-redo/undoRedoManager.ts
+++ b/src/types/undo-redo/undoRedoManager.ts
@@ -1,5 +1,4 @@
 import { ViewGraph } from "../graphs/viewgraph";
-import { deselectElement } from "../viewportManager";
 import { Move } from "./moves/move";
 
 export class UndoRedoManager {
@@ -30,9 +29,6 @@ export class UndoRedoManager {
       }
     }
     this.notifyListeners();
-    console.log(this.redoBuf);
-    console.log(this.undoBuf);
-    deselectElement();
   }
 
   /**
@@ -49,9 +45,6 @@ export class UndoRedoManager {
       }
     }
     this.notifyListeners();
-    console.log(this.redoBuf);
-    console.log(this.undoBuf);
-    deselectElement();
   }
 
   canUndo(): boolean {

--- a/src/types/viewportManager.ts
+++ b/src/types/viewportManager.ts
@@ -1,5 +1,5 @@
 import { GlobalContext } from "./../context";
-import { DataGraph, GraphData, GraphNode, NewDevice } from "./graphs/datagraph";
+import { DataGraph, GraphData, NewDevice } from "./graphs/datagraph";
 import { Device } from "./devices/index";
 import { Edge } from "./edge";
 import { RightBar } from "../graphics/right_bar";

--- a/src/types/viewportManager.ts
+++ b/src/types/viewportManager.ts
@@ -116,11 +116,9 @@ function setUpDeviceInfo(ctx: GlobalContext, type: DeviceType): NewDevice {
   );
   const mac = ctx.getNextMac();
   if (type == DeviceType.Switch) {
-    // TODO: avoid using negative ID as placeholder
     return { x, y, type, mac };
   }
   const { ip, mask } = ctx.getNextIp();
-  // TODO: avoid using negative ID as placeholder
   return { x, y, type, mac, ip, mask };
 }
 

--- a/src/types/viewportManager.ts
+++ b/src/types/viewportManager.ts
@@ -144,7 +144,7 @@ export function addDevice(ctx: GlobalContext, type: DeviceType) {
   const deviceData: CreateDevice = { id, node, connections };
 
   // Add the Device to the graph
-  const newDevice = viewgraph.addDevice(deviceData);
+  const newDevice = viewgraph.loadDevice(deviceData.id);
 
   const move = new AddDeviceMove(viewgraph.getLayer(), deviceData);
   urManager.push(move);

--- a/src/types/viewportManager.ts
+++ b/src/types/viewportManager.ts
@@ -1,5 +1,5 @@
 import { GlobalContext } from "./../context";
-import { DataGraph, GraphData, GraphNode } from "./graphs/datagraph";
+import { DataGraph, GraphData, GraphNode, NewDevice } from "./graphs/datagraph";
 import { Device } from "./devices/index";
 import { Edge } from "./edge";
 import { RightBar } from "../graphics/right_bar";
@@ -107,7 +107,7 @@ document.addEventListener("keydown", (event) => {
   }
 });
 
-function setUpDeviceInfo(ctx: GlobalContext, type: DeviceType): GraphNode {
+function setUpDeviceInfo(ctx: GlobalContext, type: DeviceType): NewDevice {
   const viewport = ctx.getViewport();
   // Get the center coordinates of the world after zoom
   const { x, y } = viewport.toWorld(
@@ -117,11 +117,11 @@ function setUpDeviceInfo(ctx: GlobalContext, type: DeviceType): GraphNode {
   const mac = ctx.getNextMac();
   if (type == DeviceType.Switch) {
     // TODO: avoid using negative ID as placeholder
-    return { id: -1, x, y, type, mac, arpTable: new Map<string, string>() };
+    return { x, y, type, mac };
   }
   const { ip, mask } = ctx.getNextIp();
   // TODO: avoid using negative ID as placeholder
-  return { id: -1, x, y, type, mac, ip, mask };
+  return { x, y, type, mac, ip, mask };
 }
 
 // Function to add a device at the center of the viewport
@@ -131,7 +131,7 @@ export function addDevice(ctx: GlobalContext, type: DeviceType) {
 
   const deviceInfo = setUpDeviceInfo(ctx, type);
 
-  const move = new AddDeviceMove(viewgraph.getLayer(), { node: deviceInfo });
+  const move = new AddDeviceMove(viewgraph.getLayer(), deviceInfo);
   urManager.push(viewgraph, move);
 }
 

--- a/src/types/viewportManager.ts
+++ b/src/types/viewportManager.ts
@@ -141,11 +141,10 @@ export function addDevice(ctx: GlobalContext, type: DeviceType) {
   const node = datagraph.getDevice(id);
   const connections = datagraph.getConnections(id);
 
-  const deviceData: CreateDevice = { id, node, connections };
-
   // Add the Device to the graph
-  const newDevice = viewgraph.loadDevice(deviceData.id);
+  const newDevice = viewgraph.loadDevice(id);
 
+  const deviceData: CreateDevice = { id, node, connections };
   const move = new AddDeviceMove(viewgraph.getLayer(), deviceData);
   urManager.push(move);
 

--- a/src/types/viewportManager.ts
+++ b/src/types/viewportManager.ts
@@ -1,5 +1,5 @@
 import { GlobalContext } from "./../context";
-import { DataGraph, GraphData } from "./graphs/datagraph";
+import { DataGraph, GraphData, GraphNode } from "./graphs/datagraph";
 import { Device } from "./devices/index";
 import { Edge } from "./edge";
 import { RightBar } from "../graphics/right_bar";
@@ -109,7 +109,7 @@ document.addEventListener("keydown", (event) => {
   }
 });
 
-function setUpDeviceInfo(ctx: GlobalContext, type: DeviceType) {
+function setUpDeviceInfo(ctx: GlobalContext, type: DeviceType): GraphNode {
   const viewport = ctx.getViewport();
   // Get the center coordinates of the world after zoom
   const { x, y } = viewport.toWorld(
@@ -118,37 +118,23 @@ function setUpDeviceInfo(ctx: GlobalContext, type: DeviceType) {
   );
   const mac = ctx.getNextMac();
   if (type == DeviceType.Switch) {
-    return { x, y, type, mac };
+    // TODO: avoid using negative ID as placeholder
+    return { id: -1, x, y, type, mac, arpTable: new Map<string, string>() };
   }
   const { ip, mask } = ctx.getNextIp();
-  return { x, y, type, mac, ip, mask };
+  // TODO: avoid using negative ID as placeholder
+  return { id: -1, x, y, type, mac, ip, mask };
 }
 
 // Function to add a device at the center of the viewport
 export function addDevice(ctx: GlobalContext, type: DeviceType) {
   console.log(`Entered addDevice with ${type}`);
   const viewgraph = ctx.getViewGraph();
-  const datagraph = ctx.getDataGraph();
 
   const deviceInfo = setUpDeviceInfo(ctx, type);
 
-  // TODO: avoid creating the device first
-  const id = datagraph.addNewDevice(deviceInfo);
-
-  // Add the Device to the graph
-  const newDevice = viewgraph.loadDevice(id);
-  const deviceData = newDevice.getCreateDevice();
-  newDevice.delete();
-
-  const move = new AddDeviceMove(viewgraph.getLayer(), deviceData);
+  const move = new AddDeviceMove(viewgraph.getLayer(), { node: deviceInfo });
   urManager.push(viewgraph, move);
-
-  console.log(
-    `${DeviceType[newDevice.getType()]} added with ID ${newDevice.id} at the center of the screen.`,
-  );
-
-  // Select the new device
-  selectElement(newDevice);
 }
 
 // Function to save the current graph in JSON format

--- a/src/types/viewportManager.ts
+++ b/src/types/viewportManager.ts
@@ -5,7 +5,6 @@ import { Edge } from "./edge";
 import { RightBar } from "../graphics/right_bar";
 import { Packet } from "./packet";
 import { DeviceType, Layer } from "./devices/device";
-import { CreateDevice } from "./devices/utils";
 import {
   UndoRedoManager,
   AddDeviceMove,

--- a/src/types/viewportManager.ts
+++ b/src/types/viewportManager.ts
@@ -72,8 +72,7 @@ document.addEventListener("keydown", (event) => {
       const viewgraph = selectedElement.viewgraph;
       const currLayer = viewgraph.getLayer();
       if (isDevice(selectedElement)) {
-        const data = selectedElement.getCreateDevice();
-        const move = new RemoveDeviceMove(currLayer, data);
+        const move = new RemoveDeviceMove(currLayer, selectedElement.id);
         urManager.push(viewgraph, move);
       } else if (isEdge(selectedElement)) {
         const connectedNodes = selectedElement.connectedNodes;


### PR DESCRIPTION
Related to #119

This PR uses the new `Graph` to specify the interface used on each connection, instead of it being implicitly the ID of the other device.