### PR TITLE
Fix MAC and IP address comparison logic in generators

### DIFF
--- a/src/packets/ethernet.ts
+++ b/src/packets/ethernet.ts
@@ -166,3 +166,11 @@ export interface FramePayload {
   // Get details of the payload
   getDetails(layer: Layer): Record<string, string | number | object>;
 }
+
+export function compareMacs(mac1: MacAddress, mac2: MacAddress): number {
+  for (let i = 0; i < 6; i++) {
+    if (mac1.octets[i] < mac2.octets[i]) return -1;
+    if (mac1.octets[i] > mac2.octets[i]) return 1;
+  }
+  return 0; // equal
+}

--- a/src/packets/ip.ts
+++ b/src/packets/ip.ts
@@ -299,3 +299,11 @@ export function computeIpChecksum(octets: Uint8Array): number {
   const carry = sum >> 16;
   return 0xffff ^ (checksum + carry);
 }
+
+export function compareIps(ip1: IpAddress, ip2: IpAddress): number {
+  for (let i = 0; i < 4; i++) {
+    if (ip1.octets[i] < ip2.octets[i]) return -1;
+    if (ip1.octets[i] > ip2.octets[i]) return 1;
+  }
+  return 0; // equal
+}


### PR DESCRIPTION
This commit corrects the comparison logic in setMacGenerator and setIpGenerator methods to accurately compare MAC and IP addresses byte by byte. 

The previous method relied on array reference comparison, which led to incorrect maximum address detection and subsequent address duplication. The newly introduced helper functions, compareMacs and compareIps, ensure element-wise comparison, preventing duplication by correctly identifying and initializing the maximum address for each generator.

before:

![image](https://github.com/user-attachments/assets/dd776ef4-8f92-4ed8-99ed-3c9d834a4326)


after:
![image](https://github.com/user-attachments/assets/b88f08a2-ae91-4629-9cae-95be602e396b)
