### PR TITLE
refactor: route packets according to interface in connection

### DIFF
--- a/src/programs/echo_sender.ts
+++ b/src/programs/echo_sender.ts
@@ -73,7 +73,7 @@ export class SingleEcho extends ProgramBase {
       }
     }
     const ethernetFrame = new EthernetFrame(srcDevice.mac, dstMac, ipPacket);
-    sendRawPacket(this.viewgraph, this.srcId, this.dstId, ethernetFrame);
+    sendRawPacket(this.viewgraph, this.srcId, ethernetFrame);
   }
 
   static getProgramInfo(viewgraph: ViewGraph, srcId: DeviceId): ProgramInfo {

--- a/src/types/devices/device.ts
+++ b/src/types/devices/device.ts
@@ -22,8 +22,7 @@ import { IpAddress } from "../../packets/ip";
 import { DeviceId, RemovedNodeData } from "../graphs/datagraph";
 import { DragDeviceMove, AddEdgeMove } from "../undo-redo";
 import { Layer } from "./layer";
-import { Packet } from "../packet";
-import { MacAddress } from "../../packets/ethernet";
+import { EthernetFrame, MacAddress } from "../../packets/ethernet";
 import { GlobalContext } from "../../context";
 
 export { Layer } from "./layer";
@@ -73,8 +72,7 @@ export abstract class Device extends Container {
    * Returns the id for the next device to send the packet to, or
    * null if there’s no next device to send the packet.
    * */
-  // TODO: Might be general for all device in the future.
-  abstract receivePacket(packet: Packet): Promise<DeviceId | null>;
+  abstract receiveFrame(frame: EthernetFrame): Promise<DeviceId | null>;
 
   constructor(
     id: DeviceId,

--- a/src/types/devices/device.ts
+++ b/src/types/devices/device.ts
@@ -72,7 +72,7 @@ export abstract class Device extends Container {
    * Returns the id for the next device to send the packet to, or
    * null if there’s no next device to send the packet.
    * */
-  abstract receiveFrame(frame: EthernetFrame): Promise<DeviceId | null>;
+  abstract receiveFrame(frame: EthernetFrame): void;
 
   constructor(
     id: DeviceId,

--- a/src/types/devices/host.ts
+++ b/src/types/devices/host.ts
@@ -15,7 +15,6 @@ import {
   Program,
   RunningProgram,
 } from "../../programs";
-import { Packet } from "../packet";
 import { Texture } from "pixi.js";
 import { MacAddress } from "../../packets/ethernet";
 import { GlobalContext } from "../../context";
@@ -46,13 +45,9 @@ export class Host extends NetworkDevice {
     this.loadRunningPrograms();
   }
 
-  receiveDatagram(packet: Packet): Promise<DeviceId | null> {
-    const datagram = packet.rawPacket.payload;
-    if (!(datagram instanceof IPv4Packet)) {
-      return null;
-    }
-    if (this.ip.equals(datagram.destinationAddress)) {
-      this.handlePacket(datagram);
+  receiveDatagram(packet: IPv4Packet): Promise<DeviceId | null> {
+    if (this.ip.equals(packet.destinationAddress)) {
+      this.handlePacket(packet);
     }
     return null;
   }

--- a/src/types/devices/networkDevice.ts
+++ b/src/types/devices/networkDevice.ts
@@ -28,7 +28,7 @@ export abstract class NetworkDevice extends Device {
     this.ipMask = ipMask;
   }
 
-  abstract receiveDatagram(packet: IPv4Packet): Promise<DeviceId | null>;
+  abstract receiveDatagram(packet: IPv4Packet): void;
 
   // TODO: Most probably it will be different for each type of device
   handlePacket(datagram: IPv4Packet) {
@@ -64,24 +64,14 @@ export abstract class NetworkDevice extends Device {
   }
 
   receiveFrame(frame: EthernetFrame): void {
-    (async (): Promise<undefined> => {
-      if (!this.mac.equals(frame.destination)) {
-        return;
-      }
-      if (!(frame.payload instanceof IPv4Packet)) {
-        console.error("Packet's type not IPv4");
-        return;
-      }
-      const datagram = frame.payload;
-      const nextHopId = await this.receiveDatagram(datagram);
-      // Wrap the datagram in a new frame
-      const nextHop = this.viewgraph.getDevice(nextHopId);
-      if (!nextHop) {
-        console.error("Next hop not found");
-        return null;
-      }
-      const newFrame = new EthernetFrame(this.mac, nextHop.mac, datagram);
-      sendRawPacket(this.viewgraph, this.id, newFrame);
-    })();
+    if (!this.mac.equals(frame.destination)) {
+      return;
+    }
+    if (!(frame.payload instanceof IPv4Packet)) {
+      console.error("Packet's type not IPv4");
+      return;
+    }
+    const datagram = frame.payload;
+    this.receiveDatagram(datagram);
   }
 }

--- a/src/types/devices/networkDevice.ts
+++ b/src/types/devices/networkDevice.ts
@@ -66,7 +66,21 @@ export abstract class NetworkDevice extends Device {
   async receiveFrame(frame: EthernetFrame): Promise<DeviceId | null> {
     if (this.mac.equals(frame.destination)) {
       if (frame.payload instanceof IPv4Packet) {
-        return this.receiveDatagram(frame.payload as IPv4Packet);
+        const datagram = frame.payload;
+        const nextHopId = await this.receiveDatagram(datagram);
+        // Wrap the datagram in a new frame
+        const nextHop = this.viewgraph.getDevice(nextHopId);
+        if (!nextHop) {
+          console.error("Next hop not found");
+          return null;
+        }
+        // TODO: send new frame
+        // const newFrame = new EthernetFrame(this.mac, dstMac, datagram);
+        // Use this device's MAC address as the source
+        frame.source = this.mac;
+        // Use the next hop's MAC address as the destination
+        frame.destination = nextHop.mac;
+        return nextHopId;
       } else {
         console.error("Packet's type not IPv4");
       }

--- a/src/types/devices/networkDevice.ts
+++ b/src/types/devices/networkDevice.ts
@@ -54,7 +54,7 @@ export abstract class NetworkDevice extends Device {
           const echoReply = new EchoReply(0);
           const ipPacket = new IPv4Packet(this.ip, dstDevice.ip, echoReply);
           const ethernet = new EthernetFrame(this.mac, dstMac, ipPacket);
-          sendRawPacket(this.viewgraph, this.id, dstDevice.id, ethernet);
+          sendRawPacket(this.viewgraph, this.id, ethernet);
         }
         break;
       }

--- a/src/types/devices/router.ts
+++ b/src/types/devices/router.ts
@@ -113,7 +113,7 @@ export class Router extends NetworkDevice {
     }
   }
 
-  routePacket(datagram: IPv4Packet): DeviceId[] | null {
+  routePacket(datagram: IPv4Packet): DeviceId[] {
     const device = this.viewgraph.getDataGraph().getDevice(this.id);
     if (!device || !isRouter(device)) {
       return;
@@ -129,6 +129,11 @@ export class Router extends NetworkDevice {
       console.debug("Considering entry:", entry);
       return datagram.destinationAddress.isInSubnet(ip, mask);
     });
+
+    if (!result) {
+      console.warn("No route found for", datagram.destinationAddress);
+      return [];
+    }
 
     const devices = this.viewgraph
       .getDataGraph()

--- a/src/types/devices/router.ts
+++ b/src/types/devices/router.ts
@@ -8,7 +8,6 @@ import { IpAddress, IPv4Packet } from "../../packets/ip";
 import { DeviceId, isRouter } from "../graphs/datagraph";
 import { Texture } from "pixi.js";
 import { MacAddress } from "../../packets/ethernet";
-import { Packet } from "../packet";
 import { GlobalContext } from "../../context";
 
 export class Router extends NetworkDevice {
@@ -89,32 +88,30 @@ export class Router extends NetworkDevice {
     return devices[0];
   }
 
-  async receiveDatagram(packet: Packet): Promise<DeviceId | null> {
-    const datagram = packet.rawPacket.payload;
-    if (!(datagram instanceof IPv4Packet)) {
-      return null;
-    }
+  async receiveDatagram(datagram: IPv4Packet): Promise<DeviceId | null> {
     if (this.ip.equals(datagram.destinationAddress)) {
       this.handlePacket(datagram);
       return null;
     }
+    // TODO: we should wrap the packet in a new frame in the caller side
+
     // a router changed forward datagram to destination, have to change current destination mac
-    const dstDevice = this.viewgraph.getDeviceByIP(datagram.destinationAddress);
-    if (!dstDevice) {
-      console.error("Destination device not found");
-      return null;
-    }
-    const path = this.viewgraph.getPathBetween(this.id, dstDevice.id);
-    let dstMac = dstDevice.mac;
-    if (!path) return null;
-    for (const id of path.slice(1)) {
-      const device = this.viewgraph.getDevice(id);
-      if (device instanceof NetworkDevice) {
-        dstMac = device.mac;
-        break;
-      }
-    }
-    packet.rawPacket.destination = dstMac;
+    // const dstDevice = this.viewgraph.getDeviceByIP(datagram.destinationAddress);
+    // if (!dstDevice) {
+    //   console.error("Destination device not found");
+    //   return null;
+    // }
+    // const path = this.viewgraph.getPathBetween(this.id, dstDevice.id);
+    // let dstMac = dstDevice.mac;
+    // if (!path) return null;
+    // for (const id of path.slice(1)) {
+    //   const device = this.viewgraph.getDevice(id);
+    //   if (device instanceof NetworkDevice) {
+    //     dstMac = device.mac;
+    //     break;
+    //   }
+    // }
+    // datagram.destination = dstMac;
     return this.routePacket(datagram);
   }
 }

--- a/src/types/devices/router.ts
+++ b/src/types/devices/router.ts
@@ -71,12 +71,12 @@ export class Router extends NetworkDevice {
 
     const result = device.routingTable.find((entry) => {
       if (entry.deleted) {
-        console.log("Skipping deleted entry:", entry);
+        console.debug("Skipping deleted entry:", entry);
         return false;
       }
       const ip = IpAddress.parse(entry.ip);
       const mask = IpAddress.parse(entry.mask);
-      console.log("Considering entry:", entry);
+      console.debug("Considering entry:", entry);
       return datagram.destinationAddress.isInSubnet(ip, mask);
     });
     const devices = this.viewgraph

--- a/src/types/devices/router.ts
+++ b/src/types/devices/router.ts
@@ -93,25 +93,6 @@ export class Router extends NetworkDevice {
       this.handlePacket(datagram);
       return null;
     }
-    // TODO: we should wrap the packet in a new frame in the caller side
-
-    // a router changed forward datagram to destination, have to change current destination mac
-    // const dstDevice = this.viewgraph.getDeviceByIP(datagram.destinationAddress);
-    // if (!dstDevice) {
-    //   console.error("Destination device not found");
-    //   return null;
-    // }
-    // const path = this.viewgraph.getPathBetween(this.id, dstDevice.id);
-    // let dstMac = dstDevice.mac;
-    // if (!path) return null;
-    // for (const id of path.slice(1)) {
-    //   const device = this.viewgraph.getDevice(id);
-    //   if (device instanceof NetworkDevice) {
-    //     dstMac = device.mac;
-    //     break;
-    //   }
-    // }
-    // datagram.destination = dstMac;
     return this.routePacket(datagram);
   }
 }

--- a/src/types/devices/router.ts
+++ b/src/types/devices/router.ts
@@ -93,16 +93,16 @@ export class Router extends NetworkDevice {
     if (!devices || devices.length === 0) {
       return;
     }
-    // TODO: send to all devices in the interface
-    const nextHopId = devices[0];
-    // Wrap the datagram in a new frame
-    const nextHop = this.viewgraph.getDevice(nextHopId);
-    if (!nextHop) {
-      console.error("Next hop not found");
-      return;
+    for (const nextHopId of devices) {
+      // Wrap the datagram in a new frame
+      const nextHop = this.viewgraph.getDevice(nextHopId);
+      if (!nextHop) {
+        console.error("Next hop not found");
+        continue;
+      }
+      const newFrame = new EthernetFrame(this.mac, nextHop.mac, datagram);
+      sendRawPacket(this.viewgraph, this.id, newFrame);
     }
-    const newFrame = new EthernetFrame(this.mac, nextHop.mac, datagram);
-    sendRawPacket(this.viewgraph, this.id, newFrame);
 
     // Stop processing packets if queue is empty
     if (this.packetQueue.length === 0) {

--- a/src/types/devices/router.ts
+++ b/src/types/devices/router.ts
@@ -139,6 +139,11 @@ export class Router extends NetworkDevice {
       .getDataGraph()
       .getConnectionsInInterface(this.id, result.iface);
 
+    if (!devices) {
+      console.error("Current device doesn't exist!", this.id);
+      return [];
+    }
+
     return devices;
   }
 }

--- a/src/types/devices/router.ts
+++ b/src/types/devices/router.ts
@@ -79,8 +79,14 @@ export class Router extends NetworkDevice {
       console.log("Considering entry:", entry);
       return datagram.destinationAddress.isInSubnet(ip, mask);
     });
-    console.log("Result:", result);
-    return result === undefined ? null : result.iface;
+    const devices = this.viewgraph
+      .getDataGraph()
+      .getConnectionsInInterface(this.id, result.iface);
+    if (!devices || devices.length === 0) {
+      return null;
+    }
+    // TODO: return more than one device
+    return devices[0];
   }
 
   async receiveDatagram(packet: Packet): Promise<DeviceId | null> {

--- a/src/types/devices/router.ts
+++ b/src/types/devices/router.ts
@@ -81,7 +81,7 @@ export class Router extends NetworkDevice {
     }
   }
 
-  async processPacket(ticker: Ticker) {
+  processPacket(ticker: Ticker) {
     this.processingProgress += ticker.deltaMS;
     if (this.processingProgress < this.timePerPacket) {
       return;

--- a/src/types/devices/switch.ts
+++ b/src/types/devices/switch.ts
@@ -8,6 +8,7 @@ import { Texture } from "pixi.js";
 import { EthernetFrame, MacAddress } from "../../packets/ethernet";
 import { IPv4Packet } from "../../packets/ip";
 import { GlobalContext } from "../../context";
+import { sendRawPacket } from "../packet";
 
 export class Switch extends Device {
   static DEVICE_TEXTURE: Texture;
@@ -43,22 +44,31 @@ export class Switch extends Device {
     return DeviceType.Switch;
   }
 
-  receiveFrame(frame: EthernetFrame): Promise<DeviceId | null> {
+  receiveFrame(frame: EthernetFrame) {
     const datagram = frame.payload;
-    if (datagram instanceof IPv4Packet) {
-      // TODO: this should add the sender to the switching table,
-      //       try to match the packet against it to find a receiver,
-      //       and broadcast it if no receiver is found
-      const dstDevice = this.viewgraph.getDeviceByIP(
-        datagram.destinationAddress,
-      );
-      if (!dstDevice) {
-        console.error("Destination device not found");
-        return null;
-      }
-      const path = this.viewgraph.getPathBetween(this.id, dstDevice.id);
-      return Promise.resolve(path.length > 1 ? path[1] : null);
+    if (!(datagram instanceof IPv4Packet)) {
+      return;
     }
-    return null;
+    // TODO: this should add the sender to the switching table,
+    //       try to match the packet against it to find a receiver,
+    //       and broadcast it if no receiver is found
+    const dstDevice = this.viewgraph.getDeviceByIP(datagram.destinationAddress);
+    if (!dstDevice) {
+      console.error("Destination device not found");
+      return;
+    }
+    const path = this.viewgraph.getPathBetween(this.id, dstDevice.id);
+    if (path.length < 2) {
+      console.error("Destination device is not reachable");
+      return;
+    }
+    const nextHopId = path[1];
+    const nextHop = this.viewgraph.getDevice(nextHopId);
+    if (!nextHop) {
+      console.error("Next hop not found");
+      return;
+    }
+    const newFrame = new EthernetFrame(this.mac, nextHop.mac, datagram);
+    sendRawPacket(this.viewgraph, this.id, newFrame);
   }
 }

--- a/src/types/devices/switch.ts
+++ b/src/types/devices/switch.ts
@@ -4,9 +4,8 @@ import SwitchImage from "../../assets/switch.svg";
 import { Position } from "../common";
 import { DeviceInfo, RightBar } from "../../graphics/right_bar";
 import { DeviceId } from "../graphs/datagraph";
-import { Packet } from "../packet";
 import { Texture } from "pixi.js";
-import { MacAddress } from "../../packets/ethernet";
+import { EthernetFrame, MacAddress } from "../../packets/ethernet";
 import { IPv4Packet } from "../../packets/ip";
 import { GlobalContext } from "../../context";
 
@@ -44,8 +43,8 @@ export class Switch extends Device {
     return DeviceType.Switch;
   }
 
-  receivePacket(packet: Packet): Promise<DeviceId | null> {
-    const datagram = packet.rawPacket.payload;
+  receiveFrame(frame: EthernetFrame): Promise<DeviceId | null> {
+    const datagram = frame.payload;
     if (datagram instanceof IPv4Packet) {
       const dstDevice = this.viewgraph.getDeviceByIP(
         datagram.destinationAddress,

--- a/src/types/devices/switch.ts
+++ b/src/types/devices/switch.ts
@@ -46,6 +46,9 @@ export class Switch extends Device {
   receiveFrame(frame: EthernetFrame): Promise<DeviceId | null> {
     const datagram = frame.payload;
     if (datagram instanceof IPv4Packet) {
+      // TODO: this should add the sender to the switching table,
+      //       try to match the packet against it to find a receiver,
+      //       and broadcast it if no receiver is found
       const dstDevice = this.viewgraph.getDeviceByIP(
         datagram.destinationAddress,
       );

--- a/src/types/graphs/datagraph.ts
+++ b/src/types/graphs/datagraph.ts
@@ -105,8 +105,7 @@ interface SwitchDataNode extends LinkDataNode {
 
 interface EdgeTip {
   id: DeviceId;
-  // TODO: uncomment this
-  // iface: number;
+  iface: number;
 }
 
 interface GraphEdge {
@@ -233,7 +232,10 @@ export class DataGraph {
       );
       return;
     }
-    const edge = { from: { id: n1Id }, to: { id: n2Id } };
+    const edge = {
+      from: { id: n1Id, iface: n2Id },
+      to: { id: n2Id, iface: n1Id },
+    };
     this.deviceGraph.setEdge(n1Id, n2Id, edge);
 
     console.log(

--- a/src/types/graphs/datagraph.ts
+++ b/src/types/graphs/datagraph.ts
@@ -290,6 +290,26 @@ export class DataGraph {
     return this.deviceGraph.getNeighbors(id);
   }
 
+  // Get all connections of a device in a given interface
+  getConnectionsInInterface(
+    id: DeviceId,
+    iface: number,
+  ): DeviceId[] | undefined {
+    if (!this.deviceGraph.hasVertex(id)) {
+      return;
+    }
+    const connections = [];
+    for (const [neighborId, { from, to }] of this.deviceGraph.getEdges(id)) {
+      if (
+        (from.id === id && from.iface === iface) ||
+        (to.id === id && to.iface === iface)
+      ) {
+        connections.push(neighborId);
+      }
+    }
+    return connections;
+  }
+
   // Method to remove a device and all its connections
   removeDevice(id: DeviceId): RemovedNodeData | undefined {
     if (!this.deviceGraph.hasVertex(id)) {

--- a/src/types/packet.ts
+++ b/src/types/packet.ts
@@ -149,6 +149,7 @@ export class Packet extends Graphics {
         deselectElement();
       }
       this.removeFromParent();
+      return;
     }
 
     // Calculate the edge length

--- a/src/types/packet.ts
+++ b/src/types/packet.ts
@@ -176,7 +176,7 @@ export class Packet extends Graphics {
       // TODO: remove this dirty hack
       // Remove and re-add from ticker to avoid multiple frames processing being triggered at once.
       ticker.remove(this.animationTick, this);
-      const newEndId = await newStartDevice.receivePacket(this);
+      const newEndId = await newStartDevice.receiveFrame(this.rawPacket);
       ticker.add(this.animationTick, this);
 
       if (newEndId === null) {


### PR DESCRIPTION
This PR continues #157 by moving routing logic to use the new interface fields. It also changes the way packets flow, making devices rewrap packets into frames and send them with `sendRawPacket`, instead of telling the `Packet` object where to go. This should simplify how we do broadcasts.