### PR TITLE
feat: show interface on edge information

### DIFF
--- a/src/types/data-devices/dDevice.ts
+++ b/src/types/data-devices/dDevice.ts
@@ -3,6 +3,13 @@ import { DataGraph, DataNode } from "../graphs/datagraph";
 import { DeviceType } from "../view-devices/vDevice";
 import { Position } from "../common";
 
+interface NetworkInterface {
+  name: string;
+  mac: MacAddress;
+  // TODO: add IP address
+  // ip?: string;
+}
+
 export abstract class DataDevice {
   private static idCounter = 1;
 
@@ -11,6 +18,7 @@ export abstract class DataDevice {
   y: number;
   mac: MacAddress;
   datagraph: DataGraph;
+  interfaces: NetworkInterface[] = [];
 
   private static setIdCounter(id: number): void {
     if (id >= DataDevice.idCounter) {
@@ -28,6 +36,12 @@ export abstract class DataDevice {
     } else {
       this.id = DataDevice.idCounter++;
     }
+    graphData.interfaces.forEach((iface) => {
+      this.interfaces.push({
+        name: iface.name,
+        mac: MacAddress.parse(iface.mac),
+      });
+    });
     this.datagraph = datagraph;
   }
 
@@ -42,6 +56,10 @@ export abstract class DataDevice {
       x: this.x,
       y: this.y,
       mac: this.mac.toString(),
+      interfaces: this.interfaces.map((iface) => ({
+        name: iface.name,
+        mac: iface.mac.toString(),
+      })),
     };
   }
 

--- a/src/types/edge.ts
+++ b/src/types/edge.ts
@@ -113,10 +113,14 @@ export class Edge extends Graphics {
 
     const info = new StyledInfo("Edge Information");
     info.addField("Connected Devices", `${from} <=> ${to}`);
-    info.addField("From Device", `${from}`);
-    info.addField("From interface", fromInterface.name);
-    info.addField("To Device", `${to}`);
-    info.addField("To interface", toInterface.name);
+    info.addField(
+      "Connected interfaces",
+      `${fromInterface.name} <=> ${toInterface.name}`,
+    );
+    info.addField(
+      "Interface MAC addresses",
+      `${fromInterface.mac} <=> ${toInterface.mac}`,
+    );
 
     // Calls renderInfo to display Edge information
     rightbar.renderInfo(info);

--- a/src/types/edge.ts
+++ b/src/types/edge.ts
@@ -9,11 +9,11 @@ import { RemoveEdgeMove } from "./undo-redo";
 import { DataEdge, DeviceId } from "./graphs/datagraph";
 
 export class Edge extends Graphics {
-  data: DataEdge;
-  startPos: Point;
-  endPos: Point;
+  private data: DataEdge;
+  private startPos: Point;
+  private endPos: Point;
+
   viewgraph: ViewGraph;
-  rightbar: RightBar;
 
   constructor(viewgraph: ViewGraph, edgeData: DataEdge) {
     super();
@@ -47,6 +47,10 @@ export class Edge extends Graphics {
       : this.data.to.id === nodeId
         ? this.endPos
         : undefined;
+  }
+
+  getDeviceIds(): DeviceId[] {
+    return [this.data.from.id, this.data.to.id];
   }
 
   otherEnd(nodeId: DeviceId): DeviceId | undefined {

--- a/src/types/edge.ts
+++ b/src/types/edge.ts
@@ -120,20 +120,7 @@ export class Edge extends Graphics {
       "Delete Edge",
       () => {
         const viewgraph = this.viewgraph;
-        // Obtener las tablas de enrutamiento antes de eliminar la conexión
-        const routingTable1 = viewgraph.getRoutingTable(from);
-        const routingTable2 = viewgraph.getRoutingTable(to);
-
-        // Crear el movimiento de eliminación de la arista con la información adicional
-        const routingTables = new Map([
-          [from, routingTable1],
-          [to, routingTable2],
-        ]);
-        const move = new RemoveEdgeMove(
-          viewgraph.getLayer(),
-          { n1: from, n2: to },
-          routingTables,
-        );
+        const move = new RemoveEdgeMove(viewgraph.getLayer(), from, to);
 
         urManager.push(viewgraph, move);
       },
@@ -151,9 +138,10 @@ export class Edge extends Graphics {
     this.destroy();
   }
 
-  destroy() {
+  destroy(): DataEdge {
     deselectElement();
     super.destroy();
+    return this.data;
   }
 
   private updatePosition(device1: ViewDevice, device2: ViewDevice) {

--- a/src/types/edge.ts
+++ b/src/types/edge.ts
@@ -68,7 +68,7 @@ export class Edge extends Graphics {
   }
 
   // Method to draw the line
-  public drawEdge(startPos: Point, endPos: Point, color: number) {
+  drawEdge(startPos: Point, endPos: Point, color: number) {
     this.clear();
     this.moveTo(startPos.x, startPos.y);
     this.lineTo(endPos.x, endPos.y);

--- a/src/types/edge.ts
+++ b/src/types/edge.ts
@@ -102,16 +102,21 @@ export class Edge extends Graphics {
     const from = this.data.from.id;
     const to = this.data.to.id;
 
+    const fromDevice = this.viewgraph.getDataGraph().getDevice(from);
+    const toDevice = this.viewgraph.getDataGraph().getDevice(to);
+    if (!fromDevice || !toDevice) {
+      console.error("One of the devices is not found in the viewgraph.");
+      return;
+    }
+    const fromInterface = fromDevice.interfaces[this.data.from.iface];
+    const toInterface = toDevice.interfaces[this.data.to.iface];
+
     const info = new StyledInfo("Edge Information");
     info.addField("Connected Devices", `${from} <=> ${to}`);
-    info.addField(
-      "Start Position",
-      `x=${this.startPos.x.toFixed(2)}, y=${this.startPos.y.toFixed(2)}`,
-    );
-    info.addField(
-      "End Position",
-      `x=${this.endPos.x.toFixed(2)}, y=${this.endPos.y.toFixed(2)}`,
-    );
+    info.addField("From Device", `${from}`);
+    info.addField("From interface", fromInterface.name);
+    info.addField("To Device", `${to}`);
+    info.addField("To interface", toInterface.name);
 
     // Calls renderInfo to display Edge information
     rightbar.renderInfo(info);

--- a/src/types/edge.ts
+++ b/src/types/edge.ts
@@ -8,11 +8,6 @@ import { Packet } from "./packet";
 import { RemoveEdgeMove } from "./undo-redo";
 import { DataEdge, DeviceId } from "./graphs/datagraph";
 
-export interface EdgeEdges {
-  n1: DeviceId;
-  n2: DeviceId;
-}
-
 export class Edge extends Graphics {
   data: DataEdge;
   startPos: Point;

--- a/src/types/graphs/datagraph.ts
+++ b/src/types/graphs/datagraph.ts
@@ -194,7 +194,9 @@ export class DataGraph {
   }
 
   // Add a connection between two devices
-  addEdge(n1Id: DeviceId, n2Id: DeviceId) {
+  addEdge(edgeData: DataEdge) {
+    const n1Id: DeviceId = edgeData.from.id;
+    const n2Id: DeviceId = edgeData.to.id;
     if (n1Id === n2Id) {
       console.warn(
         `Cannot create a connection between the same device (ID ${n1Id}).`,
@@ -215,11 +217,7 @@ export class DataGraph {
       );
       return;
     }
-    const edge = {
-      from: { id: n1Id, iface: n2Id },
-      to: { id: n2Id, iface: n1Id },
-    };
-    this.deviceGraph.setEdge(n1Id, n2Id, edge);
+    this.deviceGraph.setEdge(n1Id, n2Id, edgeData);
 
     console.log(
       `Connection created between devices ID: ${n1Id} and ID: ${n2Id}`,

--- a/src/types/graphs/datagraph.ts
+++ b/src/types/graphs/datagraph.ts
@@ -99,12 +99,12 @@ export type DataNode =
   | HostDataNode
   | SwitchDataNode;
 
-interface EdgeTip {
+export interface EdgeTip {
   id: DeviceId;
   iface: number;
 }
 
-interface DataEdge {
+export interface DataEdge {
   from: EdgeTip;
   to: EdgeTip;
 }

--- a/src/types/graphs/datagraph.ts
+++ b/src/types/graphs/datagraph.ts
@@ -229,11 +229,32 @@ export class DataGraph {
 
   // Add a connection between two devices
   addNewEdge(n1Id: DeviceId, n2Id: DeviceId): DataEdge | null {
+    const device1 = this.getDevice(n1Id);
+    const device2 = this.getDevice(n2Id);
+    if (!device1 || !device2) {
+      console.warn(
+        `Cannot create a connection between devices ${n1Id} and ${n2Id}.`,
+      );
+      return null;
+    }
+    const n1Iface = this.getNextInterfaceNumber(device1);
+    const n2Iface = this.getNextInterfaceNumber(device2);
     const edge = {
-      from: { id: n1Id, iface: n2Id },
-      to: { id: n2Id, iface: n1Id },
+      from: { id: n1Id, iface: n1Iface },
+      to: { id: n2Id, iface: n2Iface },
     };
     return this.reAddEdge(edge);
+  }
+
+  private getNextInterfaceNumber(device: DataDevice): number {
+    const numberOfInterfaces = getNumberOfInterfaces(device.getType());
+    const ifaceUses = new Array(numberOfInterfaces).map((_, i) => [
+      i,
+      this.getConnectionsInInterface(device.id, i).length,
+    ]);
+    ifaceUses.sort(([, a], [, b]) => a - b);
+    // Return the interface with the least connections
+    return ifaceUses[0][0];
   }
 
   updateDevicePosition(id: DeviceId, newValues: { x?: number; y?: number }) {

--- a/src/types/graphs/datagraph.ts
+++ b/src/types/graphs/datagraph.ts
@@ -193,29 +193,29 @@ export class DataGraph {
     return deviceId;
   }
 
-  // Add a connection between two devices
-  addEdge(edgeData: DataEdge) {
-    const n1Id: DeviceId = edgeData.from.id;
-    const n2Id: DeviceId = edgeData.to.id;
+  reAddEdge(edgeData: DataEdge): DataEdge | null {
+    const { from, to } = edgeData;
+    const n1Id = from.id;
+    const n2Id = to.id;
     if (n1Id === n2Id) {
       console.warn(
         `Cannot create a connection between the same device (ID ${n1Id}).`,
       );
-      return;
+      return null;
     }
     if (!this.deviceGraph.hasVertex(n1Id)) {
       console.warn(`Device with ID ${n1Id} does not exist.`);
-      return;
+      return null;
     }
     if (!this.deviceGraph.hasVertex(n2Id)) {
       console.warn(`Device with ID ${n2Id} does not exist.`);
-      return;
+      return null;
     }
     if (this.deviceGraph.hasEdge(n1Id, n2Id)) {
       console.warn(
         `Connection between ID ${n1Id} and ID ${n2Id} already exists.`,
       );
-      return;
+      return null;
     }
     this.deviceGraph.setEdge(n1Id, n2Id, edgeData);
 
@@ -224,6 +224,16 @@ export class DataGraph {
     );
     this.notifyChanges();
     this.regenerateAllRoutingTables();
+    return edgeData;
+  }
+
+  // Add a connection between two devices
+  addNewEdge(n1Id: DeviceId, n2Id: DeviceId): DataEdge | null {
+    const edge = {
+      from: { id: n1Id, iface: n2Id },
+      to: { id: n2Id, iface: n1Id },
+    };
+    return this.reAddEdge(edge);
   }
 
   updateDevicePosition(id: DeviceId, newValues: { x?: number; y?: number }) {

--- a/src/types/graphs/datagraph.ts
+++ b/src/types/graphs/datagraph.ts
@@ -14,27 +14,35 @@ import { GlobalContext } from "../../context";
 
 export type DeviceId = VertexId;
 
-interface CommonDataNode {
-  id?: DeviceId;
-  x: number;
-  y: number;
-  type: DeviceType;
-  mac: string;
-  interfaces: NetworkInterfaceData[];
-  arpTable?: Map<string, string>;
+export function getNumberOfInterfaces(type: DeviceType): number {
+  return NumberOfInterfacesPerType[type];
 }
 
-export const NumberOfInterfacesPerType = {
+const NumberOfInterfacesPerType = {
   [DeviceType.Host]: 1,
   [DeviceType.Router]: 4,
   [DeviceType.Switch]: 8,
 };
 
-interface NetworkInterfaceData {
+interface CommonDataNode {
+  id?: DeviceId;
+  x: number;
+  y: number;
+  type: DeviceType;
+  // TODO: remove this
+  mac: string;
+  interfaces: NetworkInterfaceData[];
+  arpTable?: Map<string, string>;
+}
+
+export interface NetworkInterfaceData {
   name: string;
   mac: string;
-  // TODO: add IP address
-  // ip?: string;
+  /**
+   * IP address of the interface.
+   * On switches this field is undefined.
+   */
+  ip?: string;
 }
 
 export interface SwitchDataNode extends CommonDataNode {
@@ -42,6 +50,7 @@ export interface SwitchDataNode extends CommonDataNode {
 }
 
 export interface NetworkDataNode extends CommonDataNode {
+  // TODO: remove this
   ip: string;
   mask: string;
 }

--- a/src/types/graphs/datagraph.ts
+++ b/src/types/graphs/datagraph.ts
@@ -248,11 +248,10 @@ export class DataGraph {
 
   private getNextInterfaceNumber(device: DataDevice): number {
     const numberOfInterfaces = getNumberOfInterfaces(device.getType());
-    const ifaceUses = new Array(numberOfInterfaces).map((_, i) => [
-      i,
-      this.getConnectionsInInterface(device.id, i).length,
-    ]);
-    ifaceUses.sort(([, a], [, b]) => a - b);
+    const ifaceUses = new Array(numberOfInterfaces)
+      .fill(0)
+      .map((_, i) => [i, this.getConnectionsInInterface(device.id, i).length])
+      .sort(([, a], [, b]) => a - b);
     // Return the interface with the least connections
     return ifaceUses[0][0];
   }

--- a/src/types/graphs/datagraph.ts
+++ b/src/types/graphs/datagraph.ts
@@ -147,11 +147,10 @@ export class DataGraph {
     const edges: DataEdge[] = [];
 
     // Serialize nodes
-    for (const [id, device] of this.deviceGraph.getAllVertices()) {
-      const type = device.getType();
+    for (const [, device] of this.deviceGraph.getAllVertices()) {
       device.getDataNode();
       // parse to serializable format
-      let dataNode: DataNode = device.getDataNode();
+      const dataNode: DataNode = device.getDataNode();
       nodes.push(dataNode);
     }
     for (const [, , edge] of this.deviceGraph.getAllEdges()) {

--- a/src/types/graphs/datagraph.ts
+++ b/src/types/graphs/datagraph.ts
@@ -20,7 +20,21 @@ interface CommonDataNode {
   y: number;
   type: DeviceType;
   mac: string;
+  interfaces: NetworkInterfaceData[];
   arpTable?: Map<string, string>;
+}
+
+export const NumberOfInterfacesPerType = {
+  [DeviceType.Host]: 1,
+  [DeviceType.Router]: 4,
+  [DeviceType.Switch]: 8,
+};
+
+interface NetworkInterfaceData {
+  name: string;
+  mac: string;
+  // TODO: add IP address
+  // ip?: string;
 }
 
 export interface SwitchDataNode extends CommonDataNode {
@@ -125,38 +139,10 @@ export class DataGraph {
 
     // Serialize nodes
     for (const [id, device] of this.deviceGraph.getAllVertices()) {
+      const type = device.getType();
+      device.getDataNode();
       // parse to serializable format
-      let dataNode: DataNode = {
-        id,
-        x: device.x,
-        y: device.y,
-        mac: device.mac.toString(),
-        type: device.getType(),
-        arpTable: new Map<string, string>(), // TODO: change this to the actual ARP table
-      };
-
-      if (device instanceof DataNetworkDevice) {
-        dataNode = {
-          ...dataNode,
-          ip: device.ip.toString(),
-          mask: device.ipMask.toString(),
-        };
-      }
-
-      if (device instanceof DataRouter) {
-        // ip and mask already set with DataNetworkDevice
-        dataNode = {
-          ...dataNode,
-          routingTable: device.routingTable,
-          packetQueueSize: device.packetQueueSize,
-          timePerByte: device.timePerByte,
-        };
-      } else if (device instanceof DataHost) {
-        dataNode = {
-          ...dataNode,
-          runningPrograms: device.runningPrograms,
-        };
-      }
+      let dataNode: DataNode = device.getDataNode();
       nodes.push(dataNode);
     }
     for (const [, , edge] of this.deviceGraph.getAllEdges()) {

--- a/src/types/graphs/datagraph.ts
+++ b/src/types/graphs/datagraph.ts
@@ -159,7 +159,7 @@ export class DataGraph {
     return { nodes, edges };
   }
 
-  readdDevice(removedData: RemovedNodeData): DeviceId {
+  reAddDevice(removedData: RemovedNodeData): DeviceId {
     const { id, vertex, edges } = removedData;
     this.deviceGraph.setVertex(id, vertex);
     edges.forEach((edge) => {

--- a/src/types/graphs/viewgraph.ts
+++ b/src/types/graphs/viewgraph.ts
@@ -1,6 +1,12 @@
 import { ViewDevice } from "../view-devices";
 import { Edge } from "./../edge";
-import { DataGraph, DeviceId, DataNode, RemovedNodeData } from "./datagraph";
+import {
+  DataGraph,
+  DeviceId,
+  DataNode,
+  RemovedNodeData,
+  DataEdge,
+} from "./datagraph";
 import { Viewport } from "../../graphics/viewport";
 import { Layer } from "../layer";
 import { createViewDevice } from "../view-devices/utils";
@@ -265,12 +271,12 @@ export class ViewGraph {
   /**
    * Remove the edge between two devices from the viewgraph and its underlying datagraph.
    */
-  removeEdge(n1Id: DeviceId, n2Id: DeviceId): boolean {
+  removeEdge(n1Id: DeviceId, n2Id: DeviceId): DataEdge | null {
     const datagraphEdge = this.datagraph.getConnection(n1Id, n2Id);
 
     if (!datagraphEdge) {
       console.warn(`Edge ${n1Id},${n2Id} is not in the datagraph`);
-      return false;
+      return null;
     }
     // Remove connection in DataGraph
     this.datagraph.removeConnection(n1Id, n2Id);
@@ -281,11 +287,11 @@ export class ViewGraph {
   /**
    * Removes the edge from the viewgraph without removing from the Datagraph.
    */
-  private _removeEdge(n1Id: DeviceId, n2Id: DeviceId): boolean {
+  private _removeEdge(n1Id: DeviceId, n2Id: DeviceId): DataEdge | null {
     const edge = this.graph.getEdge(n1Id, n2Id);
     if (!edge) {
       console.warn(`Edge ${n1Id},${n2Id} is not in the viewgraph.`);
-      return false;
+      return null;
     }
 
     // Remove the edge from the viewport
@@ -297,7 +303,7 @@ export class ViewGraph {
     console.log(
       `Edge with ID ${n1Id},${n2Id} successfully removed from ViewGraph.`,
     );
-    return true;
+    return edge.destroy();
   }
 
   getViewport() {

--- a/src/types/graphs/viewgraph.ts
+++ b/src/types/graphs/viewgraph.ts
@@ -94,14 +94,21 @@ export class ViewGraph {
     });
   }
 
-  drawEdge(device1: ViewDevice, device2: ViewDevice): Edge {
+  private drawEdge(device1: ViewDevice, device2: ViewDevice): Edge {
     const connectedNodes: EdgeEdges = { n1: device1.id, n2: device2.id };
     if (this.graph.hasEdge(device1.id, device2.id)) {
       console.warn(`Edge with ID ${device1.id},${device2.id} already exists.`);
       return this.graph.getEdge(device1.id, device2.id);
     }
+    const edgeData = this.datagraph.getConnection(device1.id, device2.id);
+    if (!edgeData) {
+      console.warn(
+        `Edge with ID ${device1.id},${device2.id} does not exist in the datagraph.`,
+      );
+      return null;
+    }
 
-    const edge = new Edge(connectedNodes, device1, device2, this);
+    const edge = new Edge(this, edgeData);
 
     this.graph.setEdge(device1.id, device2.id, edge);
     this.viewport.addChild(edge);
@@ -131,9 +138,9 @@ export class ViewGraph {
     const device2 = this.graph.getVertex(device2Id);
 
     if (device1 && device2) {
-      const edge = this.drawEdge(device1, device2);
-
       this.datagraph.addEdge(device1Id, device2Id);
+
+      const edge = this.drawEdge(device1, device2);
 
       console.log(
         `Connection created between devices ID: ${device1Id} and ID: ${device2Id}`,

--- a/src/types/graphs/viewgraph.ts
+++ b/src/types/graphs/viewgraph.ts
@@ -121,7 +121,9 @@ export class ViewGraph {
     return edge;
   }
 
-  addEdge(device1Id: DeviceId, device2Id: DeviceId): boolean {
+  addEdge(edgeData: DataEdge): boolean {
+    const device1Id = edgeData.from.id;
+    const device2Id = edgeData.to.id;
     if (device1Id === device2Id) {
       console.warn(
         `Cannot create a connection between the same device (ID ${device1Id}).`,
@@ -143,7 +145,7 @@ export class ViewGraph {
     const device2 = this.graph.getVertex(device2Id);
 
     if (device1 && device2) {
-      this.datagraph.addEdge(device1Id, device2Id);
+      this.datagraph.addEdge(edgeData);
 
       this.drawEdge(device1, device2);
 

--- a/src/types/undo-redo/moves/addRemoveDevice.ts
+++ b/src/types/undo-redo/moves/addRemoveDevice.ts
@@ -46,7 +46,7 @@ export abstract class AddRemoveDeviceMove extends BaseMove {
       id = datagraph.addDevice(this.state.data);
     } else if (wasRemoved(this.state)) {
       // Re-add the removed device
-      id = datagraph.readdDevice(this.state.removedData);
+      id = datagraph.reAddDevice(this.state.removedData);
       datagraph.regenerateAllRoutingTables();
       // Discard removed data
     }

--- a/src/types/undo-redo/moves/addRemoveDevice.ts
+++ b/src/types/undo-redo/moves/addRemoveDevice.ts
@@ -48,7 +48,6 @@ export abstract class AddRemoveDeviceMove extends BaseMove {
       // Re-add the removed device
       id = datagraph.reAddDevice(this.state.removedData);
       datagraph.regenerateAllRoutingTables();
-      // Discard removed data
     }
     this.state = { id };
     this.adjustLayer(viewgraph);

--- a/src/types/undo-redo/moves/addRemoveEdge.ts
+++ b/src/types/undo-redo/moves/addRemoveEdge.ts
@@ -1,55 +1,78 @@
 import { Layer } from "../../layer";
-import { DeviceId, RoutingTableEntry } from "../../graphs/datagraph";
+import { DataEdge, DeviceId, RoutingTableEntry } from "../../graphs/datagraph";
 import { ViewGraph } from "../../graphs/viewgraph";
 import { deselectElement } from "../../viewportManager";
 import { BaseMove } from "./move";
 
-// TODO: remove
-interface EdgeEdges {
-  n1: DeviceId;
-  n2: DeviceId;
+type EdgeState =
+  // Edge is new / was removed
+  | { data: DataEdge }
+  // Edge is in graph
+  | { n1: DeviceId; n2: DeviceId };
+
+function isInGraph(state: EdgeState): state is { n1: DeviceId; n2: DeviceId } {
+  return "n1" in state;
 }
 
 export abstract class AddRemoveEdgeMove extends BaseMove {
-  connectedNodes: EdgeEdges;
+  private state: EdgeState;
 
-  constructor(layer: Layer, connectedNodes: EdgeEdges) {
+  constructor(layer: Layer, state: EdgeState) {
     super(layer);
-    this.connectedNodes = connectedNodes;
+    this.state = state;
   }
 
   addEdge(viewgraph: ViewGraph) {
-    const { n1, n2 } = this.connectedNodes;
-
+    if (isInGraph(this.state)) {
+      console.error("Edge is already in graph");
+      return false;
+    }
     this.adjustLayer(viewgraph);
 
-    const device1 = viewgraph.getDevice(n1);
-    const device2 = viewgraph.getDevice(n2);
-    if (!device1 || !device2) {
-      console.warn("Edge's devices not found in viewgraph");
+    const n1 = this.state.data.from.id;
+    const n2 = this.state.data.to.id;
+
+    // Add the new edge
+    // TODO: update
+    const ok = viewgraph.addEdge(n1, n2);
+    if (!ok) {
+      console.warn("Edge data is invalid");
       return false;
     }
-    if (!viewgraph.addEdge(n1, n2)) {
-      console.warn("Edge already exists");
-      return false;
-    }
+    this.state = { n1, n2 };
     return true;
   }
 
   removeEdge(viewgraph: ViewGraph) {
-    this.adjustLayer(viewgraph);
-    const { n1, n2 } = this.connectedNodes;
-    const ok = viewgraph.removeEdge(n1, n2);
-    // Avoid deselecting in case of failure, since it's probably a virtual edge
-    if (ok) {
-      // Deselect to avoid showing the information of the deleted edge
-      deselectElement();
+    if (!isInGraph(this.state)) {
+      console.error("Tried to remove already removed edge");
+      return false;
     }
-    return ok;
+
+    this.adjustLayer(viewgraph);
+
+    // Remove the edge
+    // TODO: update
+    const edgeData = viewgraph.removeEdge(this.state.n1, this.state.n2);
+
+    // Avoid deselecting in case of failure, since it's probably a virtual edge
+    if (!edgeData) {
+      return false;
+    }
+
+    // TODO: store routing tables
+    this.state = { data: edgeData };
+    // Deselect to avoid showing the information of the deleted edge
+    deselectElement();
+    return true;
   }
 }
 
 export class AddEdgeMove extends AddRemoveEdgeMove {
+  constructor(layer: Layer, edgeData: DataEdge) {
+    super(layer, { data: edgeData });
+  }
+
   undo(viewgraph: ViewGraph): boolean {
     return this.removeEdge(viewgraph);
   }
@@ -60,27 +83,12 @@ export class AddEdgeMove extends AddRemoveEdgeMove {
 }
 
 export class RemoveEdgeMove extends AddRemoveEdgeMove {
-  private storedRoutingTables: Map<DeviceId, RoutingTableEntry[]>;
-
-  constructor(
-    layer: Layer,
-    connectedNodes: EdgeEdges,
-    storedRoutingTables: Map<DeviceId, RoutingTableEntry[]>,
-  ) {
-    super(layer, connectedNodes);
-    this.storedRoutingTables = storedRoutingTables;
+  constructor(layer: Layer, n1: DeviceId, n2: DeviceId) {
+    super(layer, { n1, n2 });
   }
 
   undo(viewgraph: ViewGraph): boolean {
-    if (!this.addEdge(viewgraph)) {
-      return false;
-    }
-
-    // Restore stored routing tables
-    this.storedRoutingTables.forEach((table, deviceId) => {
-      viewgraph.getDataGraph().setRoutingTable(deviceId, table);
-    });
-    return true;
+    return this.addEdge(viewgraph);
   }
 
   redo(viewgraph: ViewGraph): boolean {

--- a/src/types/undo-redo/moves/addRemoveEdge.ts
+++ b/src/types/undo-redo/moves/addRemoveEdge.ts
@@ -34,7 +34,7 @@ export abstract class AddRemoveEdgeMove extends BaseMove {
 
     // Add the new edge
     // TODO: update
-    const ok = viewgraph.addEdge(n1, n2);
+    const ok = viewgraph.addEdge(this.state.data);
     if (!ok) {
       console.warn("Edge data is invalid");
       return false;
@@ -63,6 +63,7 @@ export abstract class AddRemoveEdgeMove extends BaseMove {
     // TODO: store routing tables
     this.state = { data: edgeData };
     // Deselect to avoid showing the information of the deleted edge
+    // TODO: this isnt needed I think
     deselectElement();
     return true;
   }

--- a/src/types/undo-redo/moves/addRemoveEdge.ts
+++ b/src/types/undo-redo/moves/addRemoveEdge.ts
@@ -1,9 +1,14 @@
 import { Layer } from "../../layer";
-import { EdgeEdges } from "../../edge";
 import { DeviceId, RoutingTableEntry } from "../../graphs/datagraph";
 import { ViewGraph } from "../../graphs/viewgraph";
 import { deselectElement } from "../../viewportManager";
 import { BaseMove } from "./move";
+
+// TODO: remove
+interface EdgeEdges {
+  n1: DeviceId;
+  n2: DeviceId;
+}
 
 export abstract class AddRemoveEdgeMove extends BaseMove {
   connectedNodes: EdgeEdges;
@@ -24,7 +29,10 @@ export abstract class AddRemoveEdgeMove extends BaseMove {
       console.warn("Edge's devices not found in viewgraph");
       return false;
     }
-    viewgraph.addEdge(n1, n2);
+    if (!viewgraph.addEdge(n1, n2)) {
+      console.warn("Edge already exists");
+      return false;
+    }
     return true;
   }
 

--- a/src/types/view-devices/vDevice.ts
+++ b/src/types/view-devices/vDevice.ts
@@ -171,10 +171,7 @@ export abstract class ViewDevice extends Container {
     // Connect both devices
     const n1 = ViewDevice.connectionTarget.id;
     const n2 = this.id;
-    const from = { id: n1, iface: 0 };
-    const to = { id: n2, iface: 0 };
-    const edgeData = { from, to };
-    const move = new AddEdgeMove(this.viewgraph.getLayer(), edgeData);
+    const move = new AddEdgeMove(this.viewgraph.getLayer(), n1, n2);
     if (urManager.push(this.viewgraph, move)) {
       refreshElement();
       ViewDevice.connectionTarget = null;

--- a/src/types/view-devices/vDevice.ts
+++ b/src/types/view-devices/vDevice.ts
@@ -171,7 +171,10 @@ export abstract class ViewDevice extends Container {
     // Connect both devices
     const n1 = ViewDevice.connectionTarget.id;
     const n2 = this.id;
-    const move = new AddEdgeMove(this.viewgraph.getLayer(), { n1, n2 });
+    const from = { id: n1, iface: 0 };
+    const to = { id: n2, iface: 0 };
+    const edgeData = { from, to };
+    const move = new AddEdgeMove(this.viewgraph.getLayer(), edgeData);
     if (urManager.push(this.viewgraph, move)) {
       refreshElement();
       ViewDevice.connectionTarget = null;

--- a/src/types/viewportManager.ts
+++ b/src/types/viewportManager.ts
@@ -1,5 +1,11 @@
 import { GlobalContext } from "./../context";
-import { DataGraph, GraphData, DataNode } from "./graphs/datagraph";
+import {
+  DataGraph,
+  GraphData,
+  DataNode,
+  getNumberOfInterfaces,
+  NetworkInterfaceData,
+} from "./graphs/datagraph";
 import { ViewDevice } from "./view-devices/";
 import { Edge } from "./edge";
 import { RightBar } from "../graphics/right_bar";
@@ -118,11 +124,25 @@ function setUpDeviceInfo(ctx: GlobalContext, type: DeviceType): DataNode {
     viewport.screenHeight / 2,
   );
   const mac = ctx.getNextMac();
-  if (type == DeviceType.Switch) {
-    return { x, y, type, mac };
+
+  const interfaces = [];
+  const numberOfInterfaces = getNumberOfInterfaces(type);
+
+  const isSwitch = type == DeviceType.Switch;
+
+  for (let i = 0; i < numberOfInterfaces; i++) {
+    const mac = ctx.getNextMac();
+    const iface: NetworkInterfaceData = { name: `eth${i}`, mac };
+    if (!isSwitch) {
+      iface.ip = ctx.getNextIp().ip;
+    }
+    interfaces.push(iface);
+  }
+  if (isSwitch) {
+    return { x, y, type, mac, interfaces };
   }
   const { ip, mask } = ctx.getNextIp();
-  return { x, y, type, mac, ip, mask };
+  return { x, y, type, mac, ip, mask, interfaces };
 }
 
 // Function to add a device at the center of the viewport

--- a/src/types/viewportManager.ts
+++ b/src/types/viewportManager.ts
@@ -84,7 +84,9 @@ document.addEventListener("keydown", (event) => {
         const move = new RemoveDeviceMove(currLayer, selectedElement.id);
         urManager.push(viewgraph, move);
       } else if (isEdge(selectedElement)) {
-        const connectedNodes = selectedElement.connectedNodes;
+        const ends = selectedElement.getDeviceIds();
+        const connectedNodes = { n1: ends[0], n2: ends[1] };
+
         // Obtener las tablas de enrutamiento antes de eliminar la conexión
         const routingTable1 = viewgraph.getRoutingTable(connectedNodes.n1);
         const routingTable2 = viewgraph.getRoutingTable(connectedNodes.n2);

--- a/src/types/viewportManager.ts
+++ b/src/types/viewportManager.ts
@@ -85,21 +85,7 @@ document.addEventListener("keydown", (event) => {
         urManager.push(viewgraph, move);
       } else if (isEdge(selectedElement)) {
         const ends = selectedElement.getDeviceIds();
-        const connectedNodes = { n1: ends[0], n2: ends[1] };
-
-        // Obtener las tablas de enrutamiento antes de eliminar la conexión
-        const routingTable1 = viewgraph.getRoutingTable(connectedNodes.n1);
-        const routingTable2 = viewgraph.getRoutingTable(connectedNodes.n2);
-
-        // Crear movimiento con las tablas de enrutamiento
-        const move = new RemoveEdgeMove(
-          currLayer,
-          connectedNodes,
-          new Map([
-            [connectedNodes.n1, routingTable1],
-            [connectedNodes.n2, routingTable2],
-          ]),
-        );
+        const move = new RemoveEdgeMove(currLayer, ends[0], ends[1]);
         urManager.push(viewgraph, move);
       } else {
         // its a packet


### PR DESCRIPTION
Depends on #191

Closes #119

This PR adds automatic interface selection for edges, enforcing a maximum number of interfaces for each device (depending on type). It also makes edge selection show information of each interface connection.

Example:

![edge selection with interface information on the left bar](https://github.com/user-attachments/assets/fa3348e4-23a3-4e16-a789-ee9f2c25dbdc)
