### PR TITLE
refactor: make `Program.run` return a promise

### DIFF
--- a/src/graphics/renderables/program_runner_info.ts
+++ b/src/graphics/renderables/program_runner_info.ts
@@ -17,18 +17,19 @@ export class ProgramRunnerInfo implements Renderable {
 
   constructor(runner: ProgramRunner, programInfos: ProgramInfo[]) {
     this.runner = runner;
-    this.addProgamRunnerLabel();
+    this.addProgramRunnerLabel();
     this.addPrograms(programInfos);
     this.addRunningProgramsList();
   }
 
-  private addProgamRunnerLabel() {
+  private addProgramRunnerLabel() {
     const labelElement = document.createElement("div");
     labelElement.className = CSS_CLASSES.CENTRAL_LABEL;
     labelElement.textContent = TOOLTIP_KEYS.PROGRAM_RUNNER;
     attachTooltip(labelElement, TOOLTIP_KEYS.PROGRAM_RUNNER);
     this.inputFields.push(labelElement);
   }
+
   private addPrograms(programs: ProgramInfo[]) {
     let selectedProgram: ProgramInfo = null;
 

--- a/src/programs/echo_sender.ts
+++ b/src/programs/echo_sender.ts
@@ -105,9 +105,7 @@ export class EchoServer extends ProgramBase {
     this.progress += ticker.deltaMS * this.viewgraph.getSpeed();
 
     if (this.progress >= delay) {
-      this.echoProgram.run(() => {
-        // Do nothing
-      });
+      this.echoProgram.run();
       this.progress -= delay;
     }
   }

--- a/src/programs/index.ts
+++ b/src/programs/index.ts
@@ -40,12 +40,13 @@ export interface ProgramRunner {
 export interface Program {
   /**
    * Starts running the program.
-   * @param signalStop Function to call when the program should stop
+   * Returns a promise that's resolved when the program stops normally.
    */
   run(): Promise<void>;
 
   /**
-   * Preemptively stops running the program.
+   * Preemptively stops the running program.
+   * Note that this does not resolve the promise returned by `run()`.
    */
   stop(): void;
 }

--- a/src/programs/index.ts
+++ b/src/programs/index.ts
@@ -42,10 +42,10 @@ export interface Program {
    * Starts running the program.
    * @param signalStop Function to call when the program should stop
    */
-  run(signalStop: () => void): void;
+  run(): Promise<void>;
 
   /**
-   * Stops running the program.
+   * Preemptively stops running the program.
    */
   stop(): void;
 }

--- a/src/types/view-devices/vHost.ts
+++ b/src/types/view-devices/vHost.ts
@@ -147,7 +147,9 @@ export class ViewHost extends ViewNetworkDevice {
     const program = newProgram(this.viewgraph, this.id, runningProgram);
 
     this.runningPrograms.set(pid, program);
-    program.run(() => this.removeRunningProgram(pid));
+    // Cleanup function to execute after the program finishes
+    const cleanup = () => this.removeRunningProgram(pid);
+    program.run().then(cleanup, cleanup);
   }
 
   private getNextPid(): Pid {


### PR DESCRIPTION
This PR refactors the `Program` interface so `Program.run` returns a `Promise` instead of receiving a callback.