### PR TITLE
refactor: updateVisibility modifications

### DIFF
--- a/src/types/edge.ts
+++ b/src/types/edge.ts
@@ -138,18 +138,17 @@ export class Edge extends Graphics {
     }
 
     // Get visible devices reachable from each device
-    const device1VisibleDevices = this.viewgraph.canReachVisibleDevice(
+    const device1CanReachVisibleDevice = this.viewgraph.canReachVisibleDevice(
       device1.id,
       device2.id,
     );
-    const device2VisibleDevices = this.viewgraph.canReachVisibleDevice(
+    const device2CanReachVisibleDevice = this.viewgraph.canReachVisibleDevice(
       device2.id,
       device1.id,
     );
 
     // Update the visibility of the edge
-    this.visible =
-      device1VisibleDevices.size > 0 && device2VisibleDevices.size > 0;
+    this.visible = device1CanReachVisibleDevice && device2CanReachVisibleDevice;
   }
 
   /**

--- a/src/types/edge.ts
+++ b/src/types/edge.ts
@@ -121,6 +121,10 @@ export class Edge extends Graphics {
     return this.data;
   }
 
+  makeVisible() {
+    this.visible = true;
+  }
+
   updateVisibility(): void {
     const device1 = this.viewgraph.getDevice(this.data.from.id);
     const device2 = this.viewgraph.getDevice(this.data.to.id);
@@ -143,21 +147,9 @@ export class Edge extends Graphics {
       device1.id,
     );
 
-    // Check if both devices depend on the same visible device
-    const sharedVisibleDevices = [...device1VisibleDevices].filter((id) =>
-      device2VisibleDevices.has(id),
-    );
-
     // Update the visibility of the edge
     this.visible =
-      sharedVisibleDevices.length === 0 &&
-      device1VisibleDevices.size > 0 &&
-      device2VisibleDevices.size > 0;
-
-    // If the edge is visible, update its position
-    if (this.visible) {
-      this.refresh();
-    }
+      device1VisibleDevices.size > 0 && device2VisibleDevices.size > 0;
   }
 
   /**

--- a/src/types/graphs/graph.ts
+++ b/src/types/graphs/graph.ts
@@ -1,5 +1,7 @@
 export type VertexId = number;
 
+type FilterFn<Vertex> = (vertexId: VertexId, vertex: Vertex) => boolean;
+
 export interface RemovedVertexData<Vertex, Edge> {
   id: VertexId;
   vertex: Vertex;
@@ -105,6 +107,43 @@ export class Graph<Vertex, Edge> {
   clear() {
     this.vertices.clear();
     this.edges.clear();
+  }
+
+  /**
+   * Travels the graph in a Depth-First Search manner.
+   * @param startId ID of the vertex to start from
+   * @param filter Function to filter vertices during traversal.
+   * If the function returns true, the vertex's neighbors are visited.
+   */
+  dfs(startId: VertexId, filter: FilterFn<Vertex>): void {
+    this.recursiveDfs(startId, filter, new Set<VertexId>());
+  }
+
+  private recursiveDfs(
+    currentId: VertexId,
+    filter: FilterFn<Vertex>,
+    visited: Set<VertexId>,
+  ) {
+    if (visited.has(currentId)) {
+      return; // Avoid cycles
+    }
+    visited.add(currentId);
+
+    const currentDevice = this.getVertex(currentId);
+    if (!currentDevice) {
+      console.warn(`Device not found: ${currentId}`);
+      return; // If the device doesn't exist, stop
+    }
+    if (!filter(currentId, currentDevice)) {
+      return; // If the filter returns false, stop
+    }
+
+    // Explore neighbors recursively
+    this.getNeighbors(currentId)?.forEach((neighborId) => {
+      if (!visited.has(neighborId)) {
+        this.recursiveDfs(neighborId, filter, visited);
+      }
+    });
   }
 }
 

--- a/src/types/graphs/viewgraph.ts
+++ b/src/types/graphs/viewgraph.ts
@@ -227,7 +227,7 @@ export class ViewGraph {
   getVisibleConnectedDeviceIds(deviceId: DeviceId): DeviceId[] {
     const visibleDevices: DeviceId[] = []; // Stores visible connected device IDs
 
-    const filter = (id: DeviceId, device: ViewDevice): boolean => {
+    const vertexFilter = (device: ViewDevice, id: DeviceId): boolean => {
       // If device is visible, add it to the set and stop traversal
       if (device.visible && id !== deviceId) {
         visibleDevices.push(id);
@@ -236,7 +236,7 @@ export class ViewGraph {
       return true;
     };
 
-    this.graph.dfs(deviceId, filter);
+    this.graph.dfs(deviceId, { vertexFilter });
 
     return visibleDevices; // Return the list of visible connected device IDs
   }
@@ -247,7 +247,7 @@ export class ViewGraph {
   ): Set<DeviceId> {
     const visibleDevices = new Set<DeviceId>();
 
-    const filter = (id: DeviceId, device: ViewDevice): boolean => {
+    const vertexFilter = (device: ViewDevice, id: DeviceId): boolean => {
       // If the device is excluded, skip it and stop traversal
       if (id === excludeId) {
         return false;
@@ -260,7 +260,7 @@ export class ViewGraph {
       return true;
     };
 
-    this.graph.dfs(startId, filter);
+    this.graph.dfs(startId, { vertexFilter });
     return visibleDevices; // Return the set of visible devices found
   }
 

--- a/src/types/graphs/viewgraph.ts
+++ b/src/types/graphs/viewgraph.ts
@@ -258,10 +258,13 @@ export class ViewGraph {
     return visibleDevices; // Return the list of visible connected device IDs
   }
 
-  canReachVisibleDevice(
-    startId: DeviceId,
-    excludeId?: DeviceId,
-  ): Set<DeviceId> {
+  /**
+   * Checks if a device can reach any visible device, excluding the specified device from traversal.
+   * @param startId ID of the device to check for
+   * @param excludeId ID of a device to be excluded from traversal
+   * @returns True if the device can reach any visible device, otherwise false.
+   */
+  canReachVisibleDevice(startId: DeviceId, excludeId: DeviceId): boolean {
     const visibleDevices = new Set<DeviceId>();
 
     const vertexFilter = (device: ViewDevice, id: DeviceId): boolean => {
@@ -281,7 +284,7 @@ export class ViewGraph {
     const edgeFilter = (edge: Edge) => edge.visible;
 
     this.graph.dfs(startId, { vertexFilter, edgeFilter });
-    return visibleDevices; // Return the set of visible devices found
+    return visibleDevices.size > 0;
   }
 
   getAllConnections(): Edge[] {


### PR DESCRIPTION
This PR works on #209 to change the way edge visibility is computed. It also moves the DFS algorithm we use to the `Graph` class.

The way edge visibility is computed in this PR is by checking if each device of an edge can reach at least a single visible device. However, when loops exist in the graph, this can lead to false positives, like:

![image](https://github.com/user-attachments/assets/01855189-aec2-4179-bca6-e2d4fb79e166)

![image](https://github.com/user-attachments/assets/fd16879f-0432-420c-9837-2eb4d8430e96)

We fix this by doing it iteratively many times, ignoring edges that were marked as invisible in previous iterations.