### PR TITLE
Feat/switching table UI

### DIFF
--- a/src/graphics/renderables/device_info.ts
+++ b/src/graphics/renderables/device_info.ts
@@ -16,7 +16,8 @@ import { ProgressBar } from "../basic_components/progress_bar";
 import { LabeledProgressBar } from "../components/labeled_progress_bar";
 import { ArpTable } from "./arp_table";
 import { Layer } from "../../types/layer";
-import { DataNetworkDevice } from "../../types/data-devices";
+import { DataNetworkDevice, DataSwitch } from "../../types/data-devices";
+import { SwitchingTable } from "./switching_table";
 
 export class DeviceInfo extends BaseInfo {
   readonly device: ViewDevice;
@@ -166,6 +167,30 @@ export class DeviceInfo extends BaseInfo {
       dataDevice.setArpTableChangeListener(() => {
         // update the ARP table in the UI
         arpTable.refreshTable();
+      });
+    } else {
+      console.warn(`Device with ID ${deviceId} is not a DataNetworkDevice.`);
+    }
+  }
+
+  addSwitchingTable(viewgraph: ViewGraph, deviceId: number): void {
+    const entries = viewgraph.getDataGraph().getSwitchingTable(deviceId);
+
+    const rows = entries.map((entry) => [entry.mac, entry.port.toString()]);
+
+    const switchingTable = new SwitchingTable({
+      rows,
+      viewgraph,
+      deviceId,
+    });
+
+    this.inputFields.push(switchingTable.toHTML());
+
+    const dataDevice = viewgraph.getDataGraph().getDevice(deviceId);
+
+    if (dataDevice instanceof DataSwitch) {
+      dataDevice.setSwitchingTableChangeListener(() => {
+        switchingTable.refreshTable();
       });
     } else {
       console.warn(`Device with ID ${deviceId} is not a DataNetworkDevice.`);

--- a/src/graphics/renderables/switching_table.ts
+++ b/src/graphics/renderables/switching_table.ts
@@ -1,0 +1,190 @@
+import { DeviceId } from "../../types/graphs/datagraph";
+import { ViewGraph } from "../../types/graphs/viewgraph";
+import { ALERT_MESSAGES } from "../../utils/constants/alert_constants";
+import { CSS_CLASSES } from "../../utils/constants/css_constants";
+import { TOOLTIP_KEYS } from "../../utils/constants/tooltips_constants";
+import { Button } from "../basic_components/button";
+import { Table } from "../basic_components/table";
+import { ToggleButton } from "../basic_components/toggle_button";
+import { showError, showSuccess } from "./alert_manager";
+
+export interface SwitchingTableProps {
+  rows: string[][]; // Rows for the table
+  viewgraph: ViewGraph; // ViewGraph instance for callbacks
+  deviceId: DeviceId; // Device ID for callbacks
+}
+
+export class SwitchingTable {
+  private container: HTMLElement;
+  private table: Table;
+  private toggleButton: ToggleButton;
+
+  constructor(private props: SwitchingTableProps) {
+    this.container = document.createElement("div");
+
+    const { onEdit, onRegenerate, onDelete } =
+      this.setSwitchingTableCallbacks();
+
+    // Create the regenerate button
+    const regenerateButton = this.createRegenerateButton(onRegenerate);
+
+    const headers = {
+      [TOOLTIP_KEYS.MAC_ADDRESS]: TOOLTIP_KEYS.MAC_ADDRESS,
+      [TOOLTIP_KEYS.PORT]: TOOLTIP_KEYS.PORT,
+      [TOOLTIP_KEYS.REGENERATE]: regenerateButton, // Add the regenerate button to the header
+    };
+
+    this.table = new Table({
+      headers: headers,
+      fieldsPerRow: 2, // MAC and Port
+      rows: props.rows,
+      editableColumns: [false, true], // Make the Port column editable
+      onEdit: onEdit,
+      onDelete: onDelete,
+      tableClasses: [CSS_CLASSES.TABLE, CSS_CLASSES.RIGHT_BAR_TABLE],
+    });
+
+    this.toggleButton = new ToggleButton({
+      text: TOOLTIP_KEYS.SWITCHING_TABLE,
+      className: CSS_CLASSES.RIGHT_BAR_TOGGLE_BUTTON,
+      onToggle: (isToggled) => {
+        const tableElement = this.table.toHTML();
+        tableElement.style.display = isToggled ? "block" : "none";
+      },
+      tooltip: TOOLTIP_KEYS.SWITCHING_TABLE,
+    });
+
+    // Initially hide the table
+    const tableElement = this.table.toHTML();
+    tableElement.style.display = "none";
+
+    this.initialize();
+  }
+
+  private initialize(): void {
+    this.container.appendChild(this.toggleButton.toHTML());
+    this.container.appendChild(this.table.toHTML());
+  }
+
+  toHTML(): HTMLElement {
+    return this.container;
+  }
+
+  updateRows(newRows: string[][]): void {
+    this.table.updateRows(newRows); // Update the table with new rows
+  }
+
+  private createRegenerateButton(
+    onRegenerateCallback: () => void,
+  ): HTMLButtonElement {
+    const regenerateButton = new Button({
+      text: "🔄",
+      classList: [CSS_CLASSES.REGENERATE_BUTTON],
+      onClick: onRegenerateCallback,
+    });
+
+    return regenerateButton.toHTML();
+  }
+
+  private OnRegenerate(): void {
+    const dataGraph = this.props.viewgraph.getDataGraph();
+
+    // clear the current switching table
+    dataGraph.clearSwitchingTable(this.props.deviceId);
+
+    this.updateRows([]);
+
+    showSuccess(ALERT_MESSAGES.SWITCHING_TABLE_CLEARED);
+  }
+
+  private setSwitchingTableCallbacks() {
+    const onDelete = (row: number) => {
+      // Get the current switching table
+      const switchingTable = this.props.viewgraph
+        .getDataGraph()
+        .getSwitchingTable(this.props.deviceId);
+
+      // Validate that the index is valid
+      if (row < 0 || row >= switchingTable.length) {
+        console.warn(`Invalid row index: ${row}`);
+        return false;
+      }
+
+      // Get the MAC corresponding to the row
+      const mac = switchingTable[row].mac;
+
+      // Remove the entry from the switching table using the MAC
+      this.props.viewgraph
+        .getDataGraph()
+        .removeSwitchingTableEntry(this.props.deviceId, mac);
+
+      return true;
+    };
+
+    const onRegenerate = () => {
+      console.log("Regenerating Switching Table...");
+      this.OnRegenerate();
+    };
+
+    const onEdit = (row: number, _col: number, newValue: string) => {
+      const isValidPort = isValidPortNumber(newValue);
+
+      if (!isValidPort) {
+        console.warn(`Invalid value: ${newValue}`);
+        return false;
+      }
+
+      // Get the current switching table
+      const switchingTable = this.props.viewgraph
+        .getDataGraph()
+        .getSwitchingTable(this.props.deviceId);
+
+      // Validate that the index is valid
+      if (row < 0 || row >= switchingTable.length) {
+        console.warn(`Invalid row index: ${row}`);
+        return false;
+      }
+
+      // Get the MAC corresponding to the row
+      const mac = switchingTable[row].mac;
+
+      // Update the Switching Table entry
+      this.props.viewgraph
+        .getDataGraph()
+        .saveSwitchingTableManualChange(
+          this.props.deviceId,
+          mac,
+          parseInt(newValue, 10),
+        );
+
+      return true;
+    };
+
+    return { onEdit, onRegenerate, onDelete };
+  }
+
+  refreshTable(): void {
+    const updatedEntries = this.props.viewgraph
+      .getDataGraph()
+      .getSwitchingTable(this.props.deviceId);
+
+    const updatedRows = updatedEntries.map((entry) => [
+      entry.mac.toString(),
+      entry.port.toString(),
+    ]);
+
+    this.updateRows(updatedRows);
+  }
+}
+
+function isValidPortNumber(port: string): boolean {
+  // verify if the port is a number between 0 and 65535
+  const portNumber = parseInt(port, 10);
+  const isValid = !isNaN(portNumber) && portNumber > 0 && portNumber <= 65535;
+
+  if (!isValid) {
+    showError(ALERT_MESSAGES.INVALID_PORT);
+  }
+
+  return isValid;
+}

--- a/src/graphics/renderables/switching_table.ts
+++ b/src/graphics/renderables/switching_table.ts
@@ -178,9 +178,9 @@ export class SwitchingTable {
 }
 
 function isValidPortNumber(port: string): boolean {
-  // verify if the port is a number between 0 and 65535
+  // verify if the port is a number
   const portNumber = parseInt(port, 10);
-  const isValid = !isNaN(portNumber) && portNumber > 0 && portNumber <= 65535;
+  const isValid = !isNaN(portNumber) && portNumber > 0;
 
   if (!isValid) {
     showError(ALERT_MESSAGES.INVALID_PORT);

--- a/src/types/data-devices/dSwitch.ts
+++ b/src/types/data-devices/dSwitch.ts
@@ -6,6 +6,7 @@ import { DataGraph, DeviceId, SwitchDataNode } from "../graphs/datagraph";
 export class DataSwitch extends DataDevice {
   //                      would be interface
   switchingTable: Map<string, DeviceId> = new Map<string, DeviceId>();
+  private switchingTableChangeListener: (() => void) | null = null;
 
   constructor(graphData: SwitchDataNode, datagraph: DataGraph) {
     super(graphData, datagraph);
@@ -21,6 +22,13 @@ export class DataSwitch extends DataDevice {
       console.debug(`Adding ${mac.toString()} to the switching table`);
       this.switchingTable.set(mac.toString(), deviceId);
     }
+    if (this.switchingTableChangeListener) {
+      this.switchingTableChangeListener();
+    }
+  }
+
+  setSwitchingTableChangeListener(listener: () => void): void {
+    this.switchingTableChangeListener = listener;
   }
 
   getDataNode(): SwitchDataNode {

--- a/src/types/graphs/datagraph.ts
+++ b/src/types/graphs/datagraph.ts
@@ -849,4 +849,95 @@ export class DataGraph {
     // Notificar los cambios
     this.notifyChanges();
   }
+
+  /**
+   * Retrieves the switching table of a switch.
+   * @param deviceId - ID of the device (switch).
+   * @returns An array of objects with the entries of the switching table.
+   */
+  getSwitchingTable(deviceId: DeviceId): { mac: string; port: number }[] {
+    const device = this.getDevice(deviceId);
+    if (!device || !(device instanceof DataSwitch)) {
+      console.warn(`Device with ID ${deviceId} is not a switch.`);
+      return [];
+    }
+
+    // Convert the Map to an array and map it to a readable format
+    return Array.from(device.switchingTable.entries()).map(([mac, port]) => ({
+      mac,
+      port,
+    }));
+  }
+
+  /**
+   * Clears the switching table of a switch.
+   * @param deviceId - ID of the device (switch).
+   */
+  clearSwitchingTable(deviceId: DeviceId): void {
+    const device = this.getDevice(deviceId);
+    if (!device || !(device instanceof DataSwitch)) {
+      console.warn(`Device with ID ${deviceId} is not a switch.`);
+      return;
+    }
+
+    // Clear the switching table
+    device.switchingTable.clear();
+    console.log(`Switching table cleared for device ID ${deviceId}.`);
+
+    // Notify changes
+    this.notifyChanges();
+  }
+
+  /**
+   * Removes a specific entry from the switching table.
+   * @param deviceId - ID of the device (switch).
+   * @param mac - MAC address of the entry to remove.
+   */
+  removeSwitchingTableEntry(deviceId: DeviceId, mac: string): void {
+    const device = this.getDevice(deviceId);
+    if (!device || !(device instanceof DataSwitch)) {
+      console.warn(`Device with ID ${deviceId} is not a switch.`);
+      return;
+    }
+
+    // Remove the entry from the Map
+    if (device.switchingTable.has(mac)) {
+      device.switchingTable.delete(mac);
+      console.log(
+        `Entry with MAC ${mac} removed from switching table of device ID ${deviceId}.`,
+      );
+      this.notifyChanges();
+    } else {
+      console.warn(
+        `Entry with MAC ${mac} not found in switching table of device ID ${deviceId}.`,
+      );
+    }
+  }
+
+  /**
+   * Manually updates an entry in the switching table.
+   * @param deviceId - ID of the device (switch).
+   * @param mac - MAC address of the entry to update.
+   * @param port - New port associated with the MAC address.
+   */
+  saveSwitchingTableManualChange(
+    deviceId: DeviceId,
+    mac: string,
+    port: number,
+  ): void {
+    const device = this.getDevice(deviceId);
+    if (!device || !(device instanceof DataSwitch)) {
+      console.warn(`Device with ID ${deviceId} is not a switch.`);
+      return;
+    }
+
+    // Update or add the entry in the Map
+    device.switchingTable.set(mac, port);
+    console.log(
+      `Updated/added entry in switching table for device ID ${deviceId}: MAC=${mac}, Port=${port}.`,
+    );
+
+    // Notify changes
+    this.notifyChanges();
+  }
 }

--- a/src/types/packet.ts
+++ b/src/types/packet.ts
@@ -29,6 +29,8 @@ import {
   IcmpPacket,
 } from "../packets/icmp";
 import { PacketInfo } from "../graphics/renderables/packet_info";
+import { showWarning } from "../graphics/renderables/alert_manager";
+import { ALERT_MESSAGES } from "../utils/constants/alert_constants";
 
 const contextPerPacketType: Record<string, GraphicsContext> = {
   HTTP: circleGraphicsContext(Colors.Hazel, 5), // for HTTP
@@ -355,6 +357,27 @@ export function sendViewPacket(
       );
     });
   }
+
+  if (nextHopId) {
+    const nextHopDevice = viewgraph.getDevice(nextHopId);
+
+    // Verify if the next hop is a valid device
+    if (!nextHopDevice) {
+      showWarning(ALERT_MESSAGES.INEXISTENT_PORT(nextHopId.toString()));
+      return;
+    }
+
+    // Verify if the next hop is a valid connection
+    const isNeighbor = viewgraph
+      .getConnections(srcId)
+      .some((edge) => edge.otherEnd(srcId) === nextHopId);
+
+    if (!isNeighbor) {
+      showWarning(ALERT_MESSAGES.NON_NEIGHBOR_PORT(nextHopId.toString()));
+      return;
+    }
+  }
+
   if (firstEdge === undefined && !nextHopId) {
     console.warn(
       "El dispositivo de origen no está conectado al destino, a un router o a un switch.",

--- a/src/types/view-devices/vNetworkDevice.ts
+++ b/src/types/view-devices/vNetworkDevice.ts
@@ -121,6 +121,8 @@ export abstract class ViewNetworkDevice extends ViewDevice {
       // Check if tpa is device ip
       if (!tpa.equals(this.ip)) {
         // drop packet
+        const frame = new EthernetFrame(this.mac, sha, packet);
+        dropPacket(this.viewgraph, this.id, frame);
         return;
       }
       // Send an ARP Reply to the requesting device
@@ -131,6 +133,8 @@ export abstract class ViewNetworkDevice extends ViewDevice {
       // Check if the reply was actually sent to device
       if (!tha.equals(this.mac) && tpa.equals(this.ip)) {
         // drop packet
+        const frame = new EthernetFrame(this.mac, sha, packet);
+        dropPacket(this.viewgraph, this.id, frame);
         return;
       }
       this.updateArpTable(sha, spa);

--- a/src/types/view-devices/vSwitch.ts
+++ b/src/types/view-devices/vSwitch.ts
@@ -44,7 +44,7 @@ export class ViewSwitch extends ViewDevice {
 
   showInfo(): void {
     const info = new DeviceInfo(this);
-    info.addEmptySpace();
+    info.addSwitchingTable(this.viewgraph, this.id);
     RightBar.getInstance().renderInfo(info);
   }
 

--- a/src/utils/constants/alert_constants.ts
+++ b/src/utils/constants/alert_constants.ts
@@ -25,5 +25,9 @@ export const ALERT_MESSAGES = {
   SWITCHING_TABLE_REGENERATED: "Switching table regenerated successfully.",
   SWITCHING_TABLE_REGENERATE_FAILED: "Failed to regenerate switching table.",
   INVALID_PORT:
-    "Invalid port number. Expected format: XX where XX is a number between 0 and 65535.",
+    "Invalid port number. Expected format: XX where XX is a positive number",
+  INEXISTENT_PORT: (deviceId: string) =>
+    `Port ${deviceId} does not exist. Please verify the switching table.`,
+  NON_NEIGHBOR_PORT: (deviceId: string) =>
+    `Port ${deviceId} is not a neighbor. Please verify the switching table.`,
 };

--- a/src/utils/constants/alert_constants.ts
+++ b/src/utils/constants/alert_constants.ts
@@ -21,4 +21,9 @@ export const ALERT_MESSAGES = {
   ARP_TABLE_REGENERATE_FAILED: "Failed to regenerate ARP table.",
   INVALID_MAC:
     "Invalid MAC address format. Expected format: XX:XX:XX:XX:XX:XX.",
+  SWITCHING_TABLE_CLEARED: "Switching table cleared successfully.",
+  SWITCHING_TABLE_REGENERATED: "Switching table regenerated successfully.",
+  SWITCHING_TABLE_REGENERATE_FAILED: "Failed to regenerate switching table.",
+  INVALID_PORT:
+    "Invalid port number. Expected format: XX where XX is a number between 0 and 65535.",
 };

--- a/src/utils/constants/tooltips_constants.ts
+++ b/src/utils/constants/tooltips_constants.ts
@@ -66,6 +66,8 @@ export const TOOLTIP_KEYS = {
   IP_REQUEST: "IP to Request",
   ARP_TABLE: "ARP Table",
   IFACE_EDITOR: "iface-editor",
+  PORT: "Port",
+  SWITCHING_TABLE: "Switching Table",
 } as const;
 
 // Tooltip Content
@@ -188,4 +190,8 @@ export const TOOLTIP_CONTENT = {
     "The ARP (Address Resolution Protocol) table maps IP addresses to MAC addresses. It is used to resolve the hardware address of a device in the same local network.",
   [TOOLTIP_KEYS.IFACE_EDITOR]:
     "Modify the network interface used by this device.",
+  [TOOLTIP_KEYS.PORT]:
+    "The port in the switching table refers to the physical or logical interface on the switch where a device is connected. It is used to forward frames to the correct destination based on the MAC address.",
+  [TOOLTIP_KEYS.SWITCHING_TABLE]:
+    "The switching table is a data structure used by switches to map MAC addresses to specific ports. It helps the switch determine where to forward incoming frames based on their destination MAC address.",
 } as const;

--- a/src/utils/constants/tooltips_constants.ts
+++ b/src/utils/constants/tooltips_constants.ts
@@ -191,7 +191,7 @@ export const TOOLTIP_CONTENT = {
   [TOOLTIP_KEYS.IFACE_EDITOR]:
     "Modify the network interface used by this device.",
   [TOOLTIP_KEYS.PORT]:
-    "The port in the switching table refers to the physical or logical interface on the switch where a device is connected. It is used to forward frames to the correct destination based on the MAC address.",
+    "The port in the switching table refers to the physical or logical interface on the switch where a device is connected. It is used to forward frames to the correct destination based on the MAC address. This should not be confused with the 'port' used in transport layer protocols (such as TCP/UDP port numbers), which identify specific applications or services.",
   [TOOLTIP_KEYS.SWITCHING_TABLE]:
     "The switching table is a data structure used by switches to map MAC addresses to specific ports. It helps the switch determine where to forward incoming frames based on their destination MAC address.",
 } as const;


### PR DESCRIPTION
Switching tables have been added, allowing the modification of the port. Currently, the system operates using device IDs. In the future, once the logic supports interface-based management, this functionality will be updated accordingly.

![image](https://github.com/user-attachments/assets/25f0c884-3d1c-4b34-96b3-9a124f18159f)

closes #214 