### PR TITLE
fix: bump up router queue size and processing speed

### DIFF
--- a/src/utils/constants/router_constants.ts
+++ b/src/utils/constants/router_constants.ts
@@ -1,5 +1,5 @@
 // Router Constants
 export const ROUTER_CONSTANTS = {
-  PACKET_QUEUE_MAX_SIZE: 1024,
-  PROCESSING_SPEED: 8,
+  PACKET_QUEUE_MAX_SIZE: 4096,
+  PROCESSING_SPEED: 1024,
 } as const;


### PR DESCRIPTION
This PR increases the router queue size and processing speed to 4096 and 1024 respectively, which were reverted on 4c74067.